### PR TITLE
Fix build and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # BinanceTraderBot
+
+Prosty bot handlujący na giełdzie Binance napisany w C# i Pythonie. Część C# obsługuje sygnały webhook i wykonuje transakcje, a moduł Python służy do optymalizacji parametrów strategii RSI.
+
+## Wymagania
+- .NET 6 SDK
+- Python 3.8+
+
+## Instalacja
+1. Zainstaluj wymagane biblioteki Pythona:
+   ```bash
+   pip install -r TradingBotTV/ml_optimizer/requirements.txt
+   ```
+2. Zbuduj projekt C#:
+   ```bash
+   dotnet build TradingBotTV/bot/BinanceTraderBot.csproj
+   ```
+
+## Uruchomienie
+1. Uzupełnij klucze API w pliku `TradingBotTV/config/settings.json`.
+2. W katalogu `TradingBotTV/bot` uruchom aplikację:
+   ```bash
+   dotnet run --project BinanceTraderBot.csproj
+   ```
+
+Bot nasłuchuje na `http://localhost:5000/webhook` i co godzinę uruchamia proces optymalizacji parametrów strategii.
+
+> **Uwaga:** W środowiskach bez dostępu do API Binance wykonywanie zapytań do `api.binance.com` może zakończyć się błędem.

--- a/TradingBotTV/bot/BinanceTraderBot.csproj
+++ b/TradingBotTV/bot/BinanceTraderBot.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/TradingBotTV/bot/OptimizerRunner.cs
+++ b/TradingBotTV/bot/OptimizerRunner.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 
+using Newtonsoft.Json.Linq;
 namespace Bot
 {
     public static class OptimizerRunner

--- a/TradingBotTV/bot/WebhookServer.cs
+++ b/TradingBotTV/bot/WebhookServer.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Linq;
 using System.Threading.Tasks;
 
+using System;
+using System.IO;
 namespace Bot
 {
     public static class WebhookServer


### PR DESCRIPTION
## Summary
- add `.csproj` project file so the C# code can be built
- fix missing using statements
- expand README with build and run instructions

## Testing
- `pip3 install -r TradingBotTV/ml_optimizer/requirements.txt`
- `python3 -m py_compile TradingBotTV/ml_optimizer/*.py`
- `dotnet build TradingBotTV/bot/BinanceTraderBot.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685aa6176e1c8320af585c8edbcff48f