### PR TITLE
Handle TradingView webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # BinanceTraderBot
+
+Zaawansowany bot handlujący na giełdzie Binance napisany w C# i Pythonie. 
+C# obsługuje sygnały z TradingView, automatycznie generuje zlecenia z wbudowanej
+strategii RSI oraz zarządza stop-lossem i take-profitem. Moduł Python służy do
+optymalizacji parametrów strategii.
+
+## Wymagania
+- .NET 6 SDK
+- Python 3.8+
+
+## Instalacja
+1. Zainstaluj wymagane biblioteki Pythona:
+   ```bash
+   pip install -r TradingBotTV/ml_optimizer/requirements.txt
+   ```
+2. Zbuduj projekt C#:
+   ```bash
+   dotnet build TradingBotTV/bot/BinanceTraderBot.csproj
+   ```
+
+## Uruchomienie
+1. Uzupełnij klucze API w pliku `TradingBotTV/config/settings.json`.
+2. W katalogu `TradingBotTV/bot` uruchom aplikację:
+   ```bash
+   dotnet run --project BinanceTraderBot.csproj
+   ```
+
+W pliku `config/settings.json` możesz ustawić dodatkowo poziom `stopLossPercent`
+i `takeProfitPercent`, które określają dystans w procentach od ceny wejścia.
+
+Bot nasłuchuje na `http://localhost:5000/webhook` i co godzinę uruchamia proces samouczenia strategii. Moduł `auto_optimizer.py` losuje nowe progi RSI na podstawie dotychczasowych wyników i zapisuje najlepsze parametry w pliku `model_state.json`. Zaktualizowane wartości są automatycznie wczytywane do konfiguracji.
+`StrategyEngine` co minutę pobiera bieżące notowania i samodzielnie składa zlecenia na podstawie RSI.
+
+### Sygnały z TradingView
+W alertach TradingView ustaw adres webhook na `http://localhost:5000/webhook`.
+Przykładowa treść powiadomienia:
+
+```json
+{
+  "ticker": "BTCUSDT",
+  "strategy": { "order_action": "buy" }
+}
+```
+Pole `order_action` może przyjmować wartości `buy` lub `sell`.
+
+Komunikaty o błędach połączeń z API są wypisywane w konsoli, dzięki czemu łatwiej zdiagnozować problemy sieciowe.
+
+> **Uwaga:** W środowiskach bez dostępu do API Binance wykonywanie zapytań do `api.binance.com` może zakończyć się błędem.

--- a/TradingBotTV/bot/BinanceTraderBot.csproj
+++ b/TradingBotTV/bot/BinanceTraderBot.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/TradingBotTV/bot/ConfigManager.cs
+++ b/TradingBotTV/bot/ConfigManager.cs
@@ -20,6 +20,8 @@ namespace Bot
         public static decimal Amount => (decimal)_config["trading"]["amount"];
         public static int RsiBuyThreshold => (int)_config["trading"]["rsiBuyThreshold"];
         public static int RsiSellThreshold => (int)_config["trading"]["rsiSellThreshold"];
+        public static decimal StopLossPercent => (decimal)_config["trading"]["stopLossPercent"];
+        public static decimal TakeProfitPercent => (decimal)_config["trading"]["takeProfitPercent"];
 
         public static void Reload() => Load();
     }

--- a/TradingBotTV/bot/OptimizerRunner.cs
+++ b/TradingBotTV/bot/OptimizerRunner.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 
+using Newtonsoft.Json.Linq;
 namespace Bot
 {
     public static class OptimizerRunner
@@ -13,7 +14,7 @@ namespace Bot
             {
                 var psi = new ProcessStartInfo();
                 psi.FileName = "python";
-                psi.Arguments = $"ml_optimizer/optimizer.py {symbol}";
+                psi.Arguments = $"ml_optimizer/auto_optimizer.py {symbol}";
                 psi.RedirectStandardOutput = true;
                 psi.RedirectStandardError = true;
                 psi.UseShellExecute = false;

--- a/TradingBotTV/bot/Program.cs
+++ b/TradingBotTV/bot/Program.cs
@@ -11,8 +11,9 @@ namespace Bot
 
             ConfigManager.Load();
 
-            // Start serwera webhook w tle
+            // Start serwera webhook i silnika strategii w tle
             Task.Run(() => WebhookServer.Start());
+            Task.Run(() => StrategyEngine.StartAsync());
 
             // Odpalamy optymalizację ML co np. 1h i przeładowujemy config
             while (true)

--- a/TradingBotTV/bot/StrategyEngine.cs
+++ b/TradingBotTV/bot/StrategyEngine.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Bot
+{
+    public static class StrategyEngine
+    {
+        private static readonly HttpClient client = new HttpClient();
+
+        public static async Task StartAsync()
+        {
+            while (true)
+            {
+                try
+                {
+                    var prices = await FetchCloses(ConfigManager.Symbol, 50);
+                    if (prices.Count >= 15)
+                    {
+                        var rsi = ComputeRsi(prices);
+                        if (rsi < ConfigManager.RsiBuyThreshold)
+                        {
+                            var trader = new BinanceTrader();
+                            await trader.ExecuteTrade("BUY");
+                        }
+                        else if (rsi > ConfigManager.RsiSellThreshold)
+                        {
+                            var trader = new BinanceTrader();
+                            await trader.ExecuteTrade("SELL");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"❌ Błąd strategii: {ex.Message}");
+                }
+
+                await Task.Delay(TimeSpan.FromMinutes(1));
+            }
+        }
+
+        private static async Task<List<decimal>> FetchCloses(string symbol, int limit)
+        {
+            var url = $"https://api.binance.com/api/v3/klines?symbol={symbol}&interval=1m&limit={limit}";
+            var json = await client.GetStringAsync(url);
+            var arr = JArray.Parse(json);
+            return arr.Select(x => decimal.Parse(x[4].ToString())).ToList();
+        }
+
+        private static decimal ComputeRsi(List<decimal> closes, int period = 14)
+        {
+            var gains = new List<decimal>();
+            var losses = new List<decimal>();
+            for (int i = 1; i < closes.Count; i++)
+            {
+                var diff = closes[i] - closes[i - 1];
+                if (diff >= 0)
+                {
+                    gains.Add(diff);
+                    losses.Add(0);
+                }
+                else
+                {
+                    gains.Add(0);
+                    losses.Add(-diff);
+                }
+            }
+            var avgGain = gains.Take(period).Average();
+            var avgLoss = losses.Take(period).Average();
+            for (int i = period; i < gains.Count; i++)
+            {
+                avgGain = (avgGain * (period - 1) + gains[i]) / period;
+                avgLoss = (avgLoss * (period - 1) + losses[i]) / period;
+            }
+            if (avgLoss == 0) return 100;
+            var rs = avgGain / avgLoss;
+            var rsi = 100 - (100 / (1 + rs));
+            return decimal.Round((decimal)rsi, 2);
+        }
+    }
+}

--- a/TradingBotTV/bot/SymbolScanner.cs
+++ b/TradingBotTV/bot/SymbolScanner.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -9,16 +10,24 @@ namespace Bot
     {
         public static async Task<List<string>> GetTradingPairsAsync()
         {
-            using var client = new HttpClient();
-            var response = await client.GetStringAsync("https://api.binance.com/api/v3/exchangeInfo");
-            var json = JObject.Parse(response);
             var pairs = new List<string>();
-
-            foreach (var symbol in json["symbols"])
+            try
             {
-                if (symbol["quoteAsset"].ToString() == "USDT" && symbol["status"].ToString() == "TRADING")
-                    pairs.Add(symbol["symbol"].ToString());
+                using var client = new HttpClient();
+                var response = await client.GetStringAsync("https://api.binance.com/api/v3/exchangeInfo");
+                var json = JObject.Parse(response);
+
+                foreach (var symbol in json["symbols"])
+                {
+                    if (symbol["quoteAsset"].ToString() == "USDT" && symbol["status"].ToString() == "TRADING")
+                        pairs.Add(symbol["symbol"].ToString());
+                }
             }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"❌ Błąd pobierania listy par: {ex.Message}");
+            }
+
             return pairs;
         }
     }

--- a/TradingBotTV/config/settings.json
+++ b/TradingBotTV/config/settings.json
@@ -7,6 +7,8 @@
     "symbol": "BTCUSDT",
     "amount": 0.001,
     "rsiBuyThreshold": 30,
-    "rsiSellThreshold": 70
+    "rsiSellThreshold": 70,
+    "stopLossPercent": 1.5,
+    "takeProfitPercent": 3.0
   }
 }

--- a/TradingBotTV/ml_optimizer/auto_optimizer.py
+++ b/TradingBotTV/ml_optimizer/auto_optimizer.py
@@ -1,0 +1,58 @@
+import json
+import os
+import random
+import sys
+
+import numpy as np
+
+from data_fetcher import fetch_klines
+from backtest import backtest_strategy
+
+STATE_PATH = os.path.join(os.path.dirname(__file__), 'model_state.json')
+
+DEFAULT_BUY = 30
+DEFAULT_SELL = 70
+
+
+def load_state():
+    if os.path.exists(STATE_PATH):
+        with open(STATE_PATH, 'r') as f:
+            data = json.load(f)
+            return data.get('buy', DEFAULT_BUY), data.get('sell', DEFAULT_SELL), data.get('pnl', -np.inf)
+    return DEFAULT_BUY, DEFAULT_SELL, -np.inf
+
+
+def save_state(buy, sell, pnl):
+    with open(STATE_PATH, 'w') as f:
+        json.dump({'buy': buy, 'sell': sell, 'pnl': pnl}, f)
+
+
+def optimize(symbol, iterations=20):
+    df = fetch_klines(symbol, interval='1h', limit=500)
+    if df.empty:
+        print('Brak danych do optymalizacji')
+        return DEFAULT_BUY, DEFAULT_SELL, -np.inf
+
+    best_buy, best_sell, best_pnl = load_state()
+
+    for _ in range(iterations):
+        buy_th = int(np.clip(np.random.normal(best_buy, 5), 10, 50))
+        sell_th = int(np.clip(np.random.normal(best_sell, 5), 50, 90))
+        pnl = backtest_strategy(df, rsi_buy_threshold=buy_th, rsi_sell_threshold=sell_th)
+        print(f'Test: Buy={buy_th}, Sell={sell_th} => PnL={pnl}')
+        if pnl > best_pnl:
+            best_pnl = pnl
+            best_buy = buy_th
+            best_sell = sell_th
+
+    save_state(best_buy, best_sell, best_pnl)
+    print(f'Najlepsze parametry: Buy={best_buy} Sell={best_sell} PnL={best_pnl}')
+    return best_buy, best_sell, best_pnl
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Użycie: python auto_optimizer.py SYMBOL')
+        sys.exit(1)
+    symbol = sys.argv[1]
+    optimize(symbol)

--- a/TradingBotTV/ml_optimizer/data_fetcher.py
+++ b/TradingBotTV/ml_optimizer/data_fetcher.py
@@ -3,8 +3,13 @@ import pandas as pd
 
 def fetch_klines(symbol, interval='1h', limit=1000):
     url = f'https://api.binance.com/api/v3/klines?symbol={symbol}&interval={interval}&limit={limit}'
-    response = requests.get(url)
-    data = response.json()
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as e:
+        print(f"Error fetching klines: {e}")
+        return pd.DataFrame(columns=['open_time', 'close'])
     
     df = pd.DataFrame(data, columns=[
         'open_time', 'open', 'high', 'low', 'close', 'volume',


### PR DESCRIPTION
## Summary
- accept TradingView-style webhook fields
- allow `ExecuteTrade` to override trading pair
- document how to send alerts from TradingView
- add self-learning optimizer that stores best parameters in `model_state.json`
- add `StrategyEngine` for automatic trading and risk management

## Testing
- `python3 -m py_compile TradingBotTV/ml_optimizer/*.py`
- `dotnet build TradingBotTV/bot/BinanceTraderBot.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa6176e1c8320af585c8edbcff48f