### PR TITLE
Add Binance data caching for ML optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Bot nasłuchuje na `http://localhost:5000/webhook` i co godzinę uruchamia proce
 
 Proces optymalizacji (`auto_optimizer.py` lub `rl_optimizer.py`) uruchamia się raz na godzinę i zapisuje najlepsze parametry w `model_state.json`.
 
+Źródłem danych do uczenia jest Binance. Moduł `data_fetcher.py` pobiera historyczne
+dane świecowe z API giełdy i zapisuje je w katalogu `ml_optimizer/data`. Przy
+braku połączenia z siecią wykorzystywana jest ostatnia zapisana kopia, dzięki
+czemu optymalizacja może przebiegać również offline.
+
 ### Narzędzia ML
 * `auto_optimizer.py` – losowe poszukiwanie progów RSI
 * `rl_optimizer.py` – prosty przykład uczenia ze wzmocnieniem

--- a/TradingBotTV/ml_optimizer/data_fetcher.py
+++ b/TradingBotTV/ml_optimizer/data_fetcher.py
@@ -1,14 +1,23 @@
+import os
 import requests
 import pandas as pd
 
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
 def fetch_klines(symbol, interval='1h', limit=1000):
     url = f'https://api.binance.com/api/v3/klines?symbol={symbol}&interval={interval}&limit={limit}'
+    csv_path = os.path.join(DATA_DIR, f'{symbol}_{interval}.csv')
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         data = response.json()
     except requests.RequestException as e:
         print(f"Error fetching klines: {e}")
+        if os.path.exists(csv_path):
+            print(f'Loading cached data from {csv_path}')
+            df = pd.read_csv(csv_path)
+            df['open_time'] = pd.to_datetime(df['open_time'])
+            return df[['open_time', 'close']]
         return pd.DataFrame(columns=['open_time', 'close'])
     
     df = pd.DataFrame(data, columns=[
@@ -19,4 +28,6 @@ def fetch_klines(symbol, interval='1h', limit=1000):
     
     df['close'] = df['close'].astype(float)
     df['open_time'] = pd.to_datetime(df['open_time'], unit='ms')
+    os.makedirs(DATA_DIR, exist_ok=True)
+    df.to_csv(csv_path, index=False)
     return df[['open_time', 'close']]


### PR DESCRIPTION
## Summary
- fetch historical candlesticks from Binance and cache them in `ml_optimizer/data`
- document offline training on cached Binance data in README

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pytest -q TradingBotTV/ml_optimizer/tests/test_backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_685b1635290883209a209f534b66f6ba