### PR TITLE
Add Polish project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Bot nasłuchuje na `http://localhost:5000/webhook` i co godzinę uruchamia proce
 
 Proces optymalizacji (`auto_optimizer.py` lub `rl_optimizer.py`) uruchamia się raz na godzinę i zapisuje najlepsze parametry w `model_state.json`.
 
+Źródłem danych do uczenia jest Binance. Moduł `data_fetcher.py` pobiera historyczne
+dane świecowe z API giełdy i zapisuje je w katalogu `ml_optimizer/data`. Przy
+braku połączenia z siecią wykorzystywana jest ostatnia zapisana kopia, dzięki
+czemu optymalizacja może przebiegać również offline.
+
 ### Narzędzia ML
 * `auto_optimizer.py` – losowe poszukiwanie progów RSI
 * `rl_optimizer.py` – prosty przykład uczenia ze wzmocnieniem
@@ -79,3 +84,5 @@ Komunikaty o błędach połączeń z API są wypisywane w konsoli, dzięki czemu
 ## Licencja
 
 Projekt jest dostępny na licencji MIT. Szczegóły znajdziesz w pliku [LICENSE](LICENSE).
+
+Więcej informacji znajdziesz w pliku [docs/README_pl.md](docs/README_pl.md).

--- a/TradingBotTV/ml_optimizer/data_fetcher.py
+++ b/TradingBotTV/ml_optimizer/data_fetcher.py
@@ -1,14 +1,23 @@
+import os
 import requests
 import pandas as pd
 
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
 def fetch_klines(symbol, interval='1h', limit=1000):
     url = f'https://api.binance.com/api/v3/klines?symbol={symbol}&interval={interval}&limit={limit}'
+    csv_path = os.path.join(DATA_DIR, f'{symbol}_{interval}.csv')
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         data = response.json()
     except requests.RequestException as e:
         print(f"Error fetching klines: {e}")
+        if os.path.exists(csv_path):
+            print(f'Loading cached data from {csv_path}')
+            df = pd.read_csv(csv_path)
+            df['open_time'] = pd.to_datetime(df['open_time'])
+            return df[['open_time', 'close']]
         return pd.DataFrame(columns=['open_time', 'close'])
     
     df = pd.DataFrame(data, columns=[
@@ -19,4 +28,6 @@ def fetch_klines(symbol, interval='1h', limit=1000):
     
     df['close'] = df['close'].astype(float)
     df['open_time'] = pd.to_datetime(df['open_time'], unit='ms')
+    os.makedirs(DATA_DIR, exist_ok=True)
+    df.to_csv(csv_path, index=False)
     return df[['open_time', 'close']]

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -1,0 +1,66 @@
+# Struktura projektu BinanceTraderBot
+
+Poniżej znajduje się opis plików i katalogów w repozytorium. Wszystkie nazwy plików zostały zachowane w oryginalnej formie, a komentarze w języku polskim wyjaśniają do czego służą.
+
+## Główne katalogi
+
+- **TradingBotTV/bot** – kod bota w C#. Obsługuje sygnały z TradingView, wykonuje zlecenia i uruchamia optymalizację ML.
+- **TradingBotTV/config** – plik `settings.json` z kluczami API i parametrami strategii.
+- **TradingBotTV/ml_optimizer** – moduły Pythona do backtestów i optymalizacji.
+- **docs** – dodatkowa dokumentacja (np. ten plik, `repo_analysis.md`).
+
+## Ważne pliki
+
+### C#
+- `Program.cs` – punkt wejścia aplikacji; uruchamia serwer webhook i silnik strategii.
+- `WebhookServer.cs` – prosty serwer HTTP nasłuchujący na `/webhook`.
+- `StrategyEngine.cs` – implementacja strategii RSI i logiki wolumenu.
+- `BinanceTrader.cs` – wysyłanie zleceń do Binance.
+- `ConfigManager.cs` – wczytywanie i aktualizowanie konfiguracji.
+- `OptimizerRunner.cs` – wywołanie optymalizatorów Pythona z poziomu C#.
+- `SymbolScanner.cs` – wyszukiwanie najpopularniejszych par handlowych.
+
+### Python (`ml_optimizer`)
+- `data_fetcher.py` – pobieranie świec z Binance i zapisywanie ich w `ml_optimizer/data` (cache dla pracy offline).
+- `backtest.py` – funkcje do obliczania RSI/MACD oraz prosty backtest strategii.
+- `auto_optimizer.py` – losowe poszukiwanie najlepszych progów RSI; wyniki zapisywane są w `model_state.json`.
+- `optimizer.py` – przykład prostej optymalizacji parametrów w pętli.
+- `compare_strategies.py` – porównanie wyników strategii RSI i MACD.
+- `rl_optimizer.py` – uproszczony przykład uczenia ze wzmocnieniem.
+- `tests/test_backtest.py` – testy jednostkowe dla modułu `backtest.py`.
+
+## Edycja ustawień
+
+Najważniejsze parametry znajdują się w pliku `TradingBotTV/config/settings.json`:
+
+```json
+{
+  "binance": {
+    "apiKey": "TWOJ_API_KEY",
+    "apiSecret": "TWOJ_SECRET_KEY"
+  },
+  "trading": {
+    "symbol": "BTCUSDT",
+    "amount": 0.001,
+    "rsiBuyThreshold": 30,
+    "rsiSellThreshold": 70,
+    "stopLossPercent": 1.5,
+    "takeProfitPercent": 3.0
+  }
+}
+```
+
+- `symbol` – domyślna para handlowa.
+- `amount` – ilość kupowana/sprzedawana w pojedynczej transakcji.
+- `rsiBuyThreshold` i `rsiSellThreshold` – progi RSI wykorzystywane w strategii.
+- `stopLossPercent` i `takeProfitPercent` – ustawienia SL/TP w procentach.
+
+Optymalizatory Pythona mogą modyfikować te wartości automatycznie (zapis w `model_state.json` i aktualizacja przez `OptimizerRunner`).
+
+## Jak uruchomić testy
+
+1. Zainstaluj zależności Pythona: `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
+2. Uruchom testy: `pytest`
+
+Pliki w C# wymagają .NET 6. Informacje o budowaniu i uruchamianiu znajdują się w głównym pliku `README.md`.
+


### PR DESCRIPTION
## Summary
- add `docs/README_pl.md` with a Polish overview of repo structure and config
- fetch Binance candle data with local caching in `data_fetcher`
- document data source and offline cache in `README`
- include empty `data` directory for cached CSVs

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pytest -q TradingBotTV/ml_optimizer/tests/test_backtest.py`


------
https://chatgpt.com/codex/tasks/task_e_685b1635290883209a209f534b66f6ba