### PR TITLE
Refactor optimizer imports

### DIFF
--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -1,0 +1,19 @@
+"""Utility exports for the :mod:`TradingBotTV.ml_optimizer` package."""
+
+from .backtest import (
+    backtest_macd_strategy,
+    backtest_strategy,
+    compare_strategies,
+    compute_macd,
+    compute_rsi,
+)
+from .data_fetcher import fetch_klines
+
+__all__ = [
+    "compute_rsi",
+    "compute_macd",
+    "backtest_strategy",
+    "backtest_macd_strategy",
+    "compare_strategies",
+    "fetch_klines",
+]

--- a/TradingBotTV/ml_optimizer/auto_optimizer.py
+++ b/TradingBotTV/ml_optimizer/auto_optimizer.py
@@ -1,12 +1,11 @@
 import json
 import os
-import random
 import sys
 
 import numpy as np
 
-from data_fetcher import fetch_klines
-from backtest import backtest_strategy
+from .data_fetcher import fetch_klines
+from .backtest import backtest_strategy
 
 STATE_PATH = os.path.join(os.path.dirname(__file__), 'model_state.json')
 

--- a/TradingBotTV/ml_optimizer/compare_strategies.py
+++ b/TradingBotTV/ml_optimizer/compare_strategies.py
@@ -1,6 +1,7 @@
 import sys
-from data_fetcher import fetch_klines
-from backtest import compare_strategies
+
+from .data_fetcher import fetch_klines
+from .backtest import compare_strategies
 
 
 def run(symbol):

--- a/TradingBotTV/ml_optimizer/optimizer.py
+++ b/TradingBotTV/ml_optimizer/optimizer.py
@@ -1,6 +1,7 @@
 import sys
-from data_fetcher import fetch_klines
-from backtest import backtest_strategy
+
+from .data_fetcher import fetch_klines
+from .backtest import backtest_strategy
 import numpy as np
 
 def optimize(symbol):

--- a/TradingBotTV/ml_optimizer/rl_optimizer.py
+++ b/TradingBotTV/ml_optimizer/rl_optimizer.py
@@ -1,7 +1,9 @@
 import json
+
 import numpy as np
-from data_fetcher import fetch_klines
-from backtest import backtest_strategy
+
+from .data_fetcher import fetch_klines
+from .backtest import backtest_strategy
 
 STATE_PATH = 'rl_state.json'
 

--- a/TradingBotTV/ml_optimizer/tests/test_backtest.py
+++ b/TradingBotTV/ml_optimizer/tests/test_backtest.py
@@ -7,7 +7,7 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from TradingBotTV.ml_optimizer.backtest import compute_rsi, compute_macd, backtest_strategy
+from TradingBotTV.ml_optimizer import compute_rsi, compute_macd, backtest_strategy
 
 
 def test_compute_rsi_basic_uptrend():


### PR DESCRIPTION
## Summary
- use relative imports inside `ml_optimizer`
- export common functions in `TradingBotTV.ml_optimizer`
- adjust tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b260b419c8320a6bde157e89a2a70