### PR TITLE
Add WebSocket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ i `takeProfitPercent`, które określają dystans w procentach od ceny wejścia.
 
 Bot nasłuchuje na `http://localhost:5000/webhook` i co godzinę uruchamia proces samouczenia strategii. Moduł `auto_optimizer.py` losuje nowe progi RSI na podstawie dotychczasowych wyników i zapisuje najlepsze parametry w pliku `model_state.json`. Zaktualizowane wartości są automatycznie wczytywane do konfiguracji.
 `StrategyEngine` co minutę pobiera bieżące notowania i samodzielnie składa zlecenia. Wysoki wolumen zwiększa szansę na wygenerowanie sygnału.
+Bot nawiązuje także stałe połączenie WebSocket z Binance, a opcjonalnie z TradingView, jeśli podasz adres w konfiguracji.
 
 Proces optymalizacji (`auto_optimizer.py` lub `rl_optimizer.py`) uruchamia się raz na godzinę i zapisuje najlepsze parametry w `model_state.json`.
 

--- a/TradingBotTV/bot/BinanceWebSocket.cs
+++ b/TradingBotTV/bot/BinanceWebSocket.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bot
+{
+    public static class BinanceWebSocket
+    {
+        public static async Task StartAsync()
+        {
+            while (true)
+            {
+                using var ws = new ClientWebSocket();
+                try
+                {
+                    var url = $"{ConfigManager.BinanceWsUrl}/{ConfigManager.Symbol.ToLower()}@ticker";
+                    await ws.ConnectAsync(new Uri(url), CancellationToken.None);
+                    Console.WriteLine($"\uD83D\uDD0C Połączono z Binance WS: {url}");
+                    var buffer = new byte[4096];
+                    while (ws.State == WebSocketState.Open)
+                    {
+                        var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                            break;
+                        }
+                        var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                        Console.WriteLine($"\uD83C\uDF10 Binance: {msg}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"❌ Błąd WebSocket Binance: {ex.Message}");
+                }
+
+                Console.WriteLine("↺ Ponawiam połączenie z Binance za 30s...");
+                await Task.Delay(TimeSpan.FromSeconds(30));
+            }
+        }
+    }
+}

--- a/TradingBotTV/bot/ConfigManager.cs
+++ b/TradingBotTV/bot/ConfigManager.cs
@@ -22,6 +22,10 @@ namespace Bot
         public static int RsiSellThreshold => (int)_config["trading"]["rsiSellThreshold"];
         public static decimal StopLossPercent => (decimal)_config["trading"]["stopLossPercent"];
         public static decimal TakeProfitPercent => (decimal)_config["trading"]["takeProfitPercent"];
+        public static string BinanceWsUrl =>
+            _config["websocket"]?["binanceUrl"]?.ToString() ?? "wss://stream.binance.com:9443/ws";
+        public static string TradingViewWsUrl =>
+            _config["websocket"]?["tradingViewUrl"]?.ToString() ?? string.Empty;
 
         public static void Reload() => Load();
 

--- a/TradingBotTV/bot/Program.cs
+++ b/TradingBotTV/bot/Program.cs
@@ -19,9 +19,11 @@ namespace Bot
                 ConfigManager.OverrideSymbol(best);
             }
 
-            // Start serwera webhook i silnika strategii w tle
+            // Start serwera webhook, silnika strategii oraz WebSocketów w tle
             Task.Run(() => WebhookServer.Start());
             Task.Run(() => StrategyEngine.StartAsync());
+            Task.Run(() => BinanceWebSocket.StartAsync());
+            Task.Run(() => TradingViewWebSocket.StartAsync());
 
             // Odpalamy optymalizację ML co np. 1h i przeładowujemy config
             while (true)

--- a/TradingBotTV/bot/TradingViewWebSocket.cs
+++ b/TradingBotTV/bot/TradingViewWebSocket.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bot
+{
+    public static class TradingViewWebSocket
+    {
+        public static async Task StartAsync()
+        {
+            if (string.IsNullOrEmpty(ConfigManager.TradingViewWsUrl))
+            {
+                Console.WriteLine("ℹ️ Nie ustawiono adresu TradingView WebSocket.");
+                return;
+            }
+
+            while (true)
+            {
+                using var ws = new ClientWebSocket();
+                try
+                {
+                    await ws.ConnectAsync(new Uri(ConfigManager.TradingViewWsUrl), CancellationToken.None);
+                    Console.WriteLine("\uD83D\uDD0C Połączono z TradingView WS");
+                    var buffer = new byte[4096];
+                    while (ws.State == WebSocketState.Open)
+                    {
+                        var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                            break;
+                        }
+                        var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                        Console.WriteLine($"\uD83C\uDF10 TradingView: {msg}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"❌ Błąd WebSocket TradingView: {ex.Message}");
+                }
+
+                Console.WriteLine("↺ Ponawiam połączenie z TradingView za 30s...");
+                await Task.Delay(TimeSpan.FromSeconds(30));
+            }
+        }
+    }
+}

--- a/TradingBotTV/config/settings.json
+++ b/TradingBotTV/config/settings.json
@@ -10,5 +10,9 @@
     "rsiSellThreshold": 70,
     "stopLossPercent": 1.5,
     "takeProfitPercent": 3.0
+  },
+  "websocket": {
+    "binanceUrl": "wss://stream.binance.com:9443/ws",
+    "tradingViewUrl": ""
   }
 }

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -46,6 +46,10 @@ Najważniejsze parametry znajdują się w pliku `TradingBotTV/config/settings.js
     "rsiSellThreshold": 70,
     "stopLossPercent": 1.5,
     "takeProfitPercent": 3.0
+  },
+  "websocket": {
+    "binanceUrl": "wss://stream.binance.com:9443/ws",
+    "tradingViewUrl": ""
   }
 }
 ```
@@ -54,6 +58,8 @@ Najważniejsze parametry znajdują się w pliku `TradingBotTV/config/settings.js
 - `amount` – ilość kupowana/sprzedawana w pojedynczej transakcji.
 - `rsiBuyThreshold` i `rsiSellThreshold` – progi RSI wykorzystywane w strategii.
 - `stopLossPercent` i `takeProfitPercent` – ustawienia SL/TP w procentach.
+- `websocket.binanceUrl` – adres WebSocket Binance z którego pobierane są dane na żywo.
+- `websocket.tradingViewUrl` – opcjonalny adres WebSocket z alertami TradingView.
 
 Optymalizatory Pythona mogą modyfikować te wartości automatycznie (zapis w `model_state.json` i aktualizacja przez `OptimizerRunner`).
 


### PR DESCRIPTION
## Summary
- add Binance and TradingView WebSocket URLs to config
- expose new websocket URLs via `ConfigManager`
- implement `BinanceWebSocket` and `TradingViewWebSocket` clients
- start the websocket clients from `Program.cs`
- document websocket settings in README files

## Testing
- `dotnet build TradingBotTV/bot/BinanceTraderBot.csproj -v q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2873b6c88320ace3f42ae4722d26