### PR TITLE
Add GitHub strategy simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ czemu optymalizacja może przebiegać również offline.
 * `auto_optimizer.py` – losowe poszukiwanie progów RSI
 * `rl_optimizer.py` – prosty przykład uczenia ze wzmocnieniem
 * `compare_strategies.py` – backtest RSI vs. MACD
+* `github_strategy_simulator.py` – klonuje repozytoria z GitHub i symuluje
+  zdefiniowane w nich strategie offline
 
 Aby uruchomić test porównawczy strategii:
 ```bash

--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -8,6 +8,7 @@ from .backtest import (
     compute_rsi,
 )
 from .data_fetcher import fetch_klines
+from .github_strategy_simulator import simulate_strategy
 
 __all__ = [
     "compute_rsi",
@@ -16,4 +17,5 @@ __all__ = [
     "backtest_macd_strategy",
     "compare_strategies",
     "fetch_klines",
+    "simulate_strategy",
 ]

--- a/TradingBotTV/ml_optimizer/github_strategy_simulator.py
+++ b/TradingBotTV/ml_optimizer/github_strategy_simulator.py
@@ -1,0 +1,76 @@
+"""Clone an external GitHub repo containing a simple strategy definition and
+run an offline backtest using local market data.
+
+Expected repository layout:
+    strategy.json
+
+strategy.json example::
+    {
+        "rsi_buy_threshold": 30,
+        "rsi_sell_threshold": 70
+    }
+
+Usage:
+    python github_strategy_simulator.py <repo_url> <symbol>
+
+If the environment lacks network access, you can provide a local path instead
+of a URL.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+
+from .data_fetcher import fetch_klines
+from .backtest import backtest_strategy
+
+
+def clone_repo(src: str, dst: str) -> None:
+    """Clone *src* into directory *dst*.
+
+    If *src* is a local path, it is copied using ``git clone`` as well.
+    Errors are printed and propagated as :class:`subprocess.CalledProcessError`.
+    """
+    print(f"Cloning repository {src}...")
+    subprocess.run(["git", "clone", "--depth", "1", src, dst], check=True)
+
+
+def load_strategy(repo_path: str) -> dict:
+    """Return strategy configuration loaded from ``strategy.json``."""
+    path = os.path.join(repo_path, "strategy.json")
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def simulate_strategy(repo: str, symbol: str) -> None:
+    """Backtest strategy from *repo* for the given *symbol* and print PnL."""
+    with TemporaryDirectory() as tmp:
+        try:
+            clone_repo(repo, tmp)
+        except subprocess.CalledProcessError as exc:
+            print(f"Error cloning repo: {exc}")
+            return
+        try:
+            cfg = load_strategy(tmp)
+        except FileNotFoundError:
+            print("strategy.json not found in repository")
+            return
+
+        buy = int(cfg.get("rsi_buy_threshold", 30))
+        sell = int(cfg.get("rsi_sell_threshold", 70))
+
+        df = fetch_klines(symbol, interval="1h", limit=500)
+        if df.empty:
+            print("No data fetched for backtest")
+            return
+        pnl = backtest_strategy(df, rsi_buy_threshold=buy, rsi_sell_threshold=sell)
+        print(f"Backtest result for {symbol}: PnL={pnl}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python github_strategy_simulator.py <repo_url> <symbol>")
+        sys.exit(1)
+    simulate_strategy(sys.argv[1], sys.argv[2])

--- a/TradingBotTV/ml_optimizer/tests/test_github_simulator.py
+++ b/TradingBotTV/ml_optimizer/tests/test_github_simulator.py
@@ -1,0 +1,40 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import github_strategy_simulator
+
+
+def test_simulate_strategy_local_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", repo], check=True)
+    strategy = {"rsi_buy_threshold": 25, "rsi_sell_threshold": 75}
+    (repo / "strategy.json").write_text(json.dumps(strategy))
+    subprocess.run(["git", "-C", str(repo), "add", "strategy.json"], check=True)
+    env = dict(os.environ,
+               GIT_AUTHOR_NAME="a",
+               GIT_AUTHOR_EMAIL="a@b.c",
+               GIT_COMMITTER_NAME="a",
+               GIT_COMMITTER_EMAIL="a@b.c")
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, env=env)
+
+    df = pd.DataFrame({"close": [1, 2, 3, 4, 5]})
+    monkeypatch.setattr(github_strategy_simulator, "fetch_klines", lambda *a, **k: df)
+    results = []
+    monkeypatch.setattr(github_strategy_simulator, "backtest_strategy",
+                        lambda data, rsi_buy_threshold, rsi_sell_threshold: 42)
+    import builtins
+    monkeypatch.setattr(builtins, "print",
+                        lambda *args, **kwargs: results.append(" ".join(map(str, args))))
+
+    github_strategy_simulator.simulate_strategy(str(repo), "BTCUSDT")
+
+    assert any("PnL" in r for r in results)

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -27,6 +27,8 @@ Poniżej znajduje się opis plików i katalogów w repozytorium. Wszystkie nazwy
 - `optimizer.py` – przykład prostej optymalizacji parametrów w pętli.
 - `compare_strategies.py` – porównanie wyników strategii RSI i MACD.
 - `rl_optimizer.py` – uproszczony przykład uczenia ze wzmocnieniem.
+- `github_strategy_simulator.py` – pobieranie strategii z publicznych repozytoriów
+  i ich symulacja offline.
 - `tests/test_backtest.py` – testy jednostkowe dla modułu `backtest.py`.
 
 ## Edycja ustawień


### PR DESCRIPTION
## Summary
- add a helper to clone GitHub repos and backtest a simple strategy
- expose the simulator via `ml_optimizer` package
- document new script in Polish and English READMEs
- test offline simulation using a local git repo

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pytest -q TradingBotTV/ml_optimizer/tests`

------
https://chatgpt.com/codex/tasks/task_e_685ba87c77148320a7c9b36c547eed84