### PR TITLE
Add async data fetcher and logging utilities

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,23 @@
+name: Python CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          pip install -r TradingBotTV/ml_optimizer/requirements.txt
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -11,21 +11,8 @@ pod uwagę wzrost aktywności wolumenowej. Dodano obsługę trailing stop oraz
 dynamiczne dostosowanie wielkości pozycji w zależności od zmienności rynku.
 Bot samoczynnie wyłącza handel, gdy łączna strata przekroczy ustawiony próg `maxDrawdownPercent`.
 
-Strategia łączy sygnały z interwałów 1m, 30m i 1h oraz filtruje trend na
-podstawie przebiegu średnich EMA (domyślnie 50 i 200 okresów). Logi zapisywane
-są do pliku `logs/bot.log`. W katalogu `ml_optimizer` znajdują się skrypty do
-trenowania rozwiniętego modelu RL (`rl_optimizer.py`) oraz testu kilku
-strategii (`compare_strategies.py`).
-Strategia łączy sygnały z interwału 1m i 1h oraz filtruje trend na podstawie
-przebiegu średnich EMA (domyślnie 50 i 200 okresów). Logi zapisywane są do
-pliku `logs/bot.log`. W katalogu `ml_optimizer` znajdują się skrypty do
-trenowania prostego modelu RL (`rl_optimizer.py`) oraz testu kilku strategii
+Strategia łączy sygnały z interwałów 1m, 30m i 1h, filtruje trend na podstawie średnich EMA (50 i 200) i zapisuje logi do pliku `logs/bot.log`. Moduł `ml_optimizer` zawiera skrypty do optymalizacji parametrów i trenowania modelu RL (`rl_optimizer.py`) oraz porównywania strategii (`compare_strategies.py`).
 
-Strategia łączy sygnały z interwału 1m i 1h, a logi zapisywane są do pliku
-`logs/bot.log`. W katalogu `ml_optimizer` znajdują się skrypty do trenowania
-prostego modelu RL (`rl_optimizer.py`) oraz testu kilku strategii
-
-(`compare_strategies.py`).
 
 
 
@@ -53,6 +40,8 @@ prostego modelu RL (`rl_optimizer.py`) oraz testu kilku strategii
 2. Zainstaluj wymagane biblioteki Pythona:
    ```bash
    pip install -r TradingBotTV/ml_optimizer/requirements.txt
+   # lub zainstaluj cały moduł
+   pip install .
    ```
 3. Zbuduj projekt C#:
    ```bash
@@ -60,7 +49,8 @@ prostego modelu RL (`rl_optimizer.py`) oraz testu kilku strategii
    ```
 
 ## Uruchomienie
-1. Uzupełnij klucze API w pliku `TradingBotTV/config/settings.json`.
+1. Uzupełnij klucze API w pliku `TradingBotTV/config/settings.json` lub ustaw
+   zmienne środowiskowe `BINANCE_API_KEY` i `BINANCE_API_SECRET`.
 2. W katalogu `TradingBotTV/bot` uruchom aplikację:
    ```bash
    dotnet run --project BinanceTraderBot.csproj

--- a/TradingBotTV/bot/ConfigManager.cs
+++ b/TradingBotTV/bot/ConfigManager.cs
@@ -19,8 +19,13 @@ namespace Bot
             _config = JObject.Parse(text);
         }
 
-        public static string ApiKey => _config["binance"]["apiKey"].ToString();
-        public static string ApiSecret => _config["binance"]["apiSecret"].ToString();
+        public static string ApiKey =>
+            Environment.GetEnvironmentVariable("BINANCE_API_KEY")
+            ?? _config["binance"]["apiKey"].ToString();
+
+        public static string ApiSecret =>
+            Environment.GetEnvironmentVariable("BINANCE_API_SECRET")
+            ?? _config["binance"]["apiSecret"].ToString();
         public static string Symbol => _config["trading"]["symbol"].ToString();
         public static decimal Amount => (decimal)_config["trading"]["amount"];
         public static decimal InitialCapital =>

--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -9,9 +9,10 @@ from .backtest import (
     compute_ema,
     compute_rsi,
 )
-from .data_fetcher import fetch_klines
+from .data_fetcher import fetch_klines, async_fetch_klines
 from .github_strategy_simulator import simulate_strategy
 from .tradingview_auto_trader import auto_trade_from_tv
+from .logger import get_logger
 
 
 __all__ = [
@@ -23,6 +24,8 @@ __all__ = [
     "backtest_macd_strategy",
     "compare_strategies",
     "fetch_klines",
+    "async_fetch_klines",
+    "get_logger",
     "simulate_strategy",
     "auto_trade_from_tv",
 ]

--- a/TradingBotTV/ml_optimizer/data_fetcher.py
+++ b/TradingBotTV/ml_optimizer/data_fetcher.py
@@ -1,37 +1,104 @@
-import os
-import requests
+from pathlib import Path
+
+import aiohttp
 import pandas as pd
+import requests
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+DATA_DIR = Path(__file__).with_name('data')
 
 
-def fetch_klines(symbol, interval='1h', limit=1000):
+def fetch_klines(symbol, interval="1h", limit=1000):
     url = (
-        'https://api.binance.com/api/v3/klines'
-        f'?symbol={symbol}&interval={interval}&limit={limit}'
+        "https://api.binance.com/api/v3/klines"
+        f"?symbol={symbol}&interval={interval}&limit={limit}"
     )
-    csv_path = os.path.join(DATA_DIR, f'{symbol}_{interval}.csv')
+    csv_path = DATA_DIR / f"{symbol}_{interval}.csv"
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         data = response.json()
     except requests.RequestException as e:
-        print(f"Error fetching klines: {e}")
-        if os.path.exists(csv_path):
-            print(f'Loading cached data from {csv_path}')
+        logger.error("Error fetching klines: %s", e)
+        if csv_path.exists():
+            logger.info("Loading cached data from %s", csv_path)
             df = pd.read_csv(csv_path)
-            df['open_time'] = pd.to_datetime(df['open_time'])
-            return df[['open_time', 'close']]
-        return pd.DataFrame(columns=['open_time', 'close'])
+            df["open_time"] = pd.to_datetime(df["open_time"])
+            return df[["open_time", "close"]]
+        return pd.DataFrame(columns=["open_time", "close"])
 
-    df = pd.DataFrame(data, columns=[
-        'open_time', 'open', 'high', 'low', 'close', 'volume',
-        'close_time', 'quote_asset_volume', 'number_of_trades',
-        'taker_buy_base_asset_volume', 'taker_buy_quote_asset_volume', 'ignore'
-    ])
+    df = pd.DataFrame(
+        data,
+        columns=[
+            "open_time",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "close_time",
+            "quote_asset_volume",
+            "number_of_trades",
+            "taker_buy_base_asset_volume",
+            "taker_buy_quote_asset_volume",
+            "ignore",
+        ],
+    )
 
     df['close'] = df['close'].astype(float)
     df['open_time'] = pd.to_datetime(df['open_time'], unit='ms')
-    os.makedirs(DATA_DIR, exist_ok=True)
+    DATA_DIR.mkdir(exist_ok=True)
     df.to_csv(csv_path, index=False)
     return df[['open_time', 'close']]
+
+
+async def async_fetch_klines(
+    symbol: str,
+    interval: str = "1h",
+    limit: int = 1000,
+):
+    """Asynchronously fetch klines from Binance."""
+    url = (
+        "https://api.binance.com/api/v3/klines"
+        f"?symbol={symbol}&interval={interval}&limit={limit}"
+    )
+    csv_path = DATA_DIR / f"{symbol}_{interval}.csv"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=10) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+    except Exception as e:  # pragma: no cover - network failure
+        logger.error("Error fetching klines: %s", e)
+        if csv_path.exists():
+            logger.info("Loading cached data from %s", csv_path)
+            df = pd.read_csv(csv_path)
+            df["open_time"] = pd.to_datetime(df["open_time"])
+            return df[["open_time", "close"]]
+        return pd.DataFrame(columns=["open_time", "close"])
+
+    df = pd.DataFrame(
+        data,
+        columns=[
+            "open_time",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "close_time",
+            "quote_asset_volume",
+            "number_of_trades",
+            "taker_buy_base_asset_volume",
+            "taker_buy_quote_asset_volume",
+            "ignore",
+        ],
+    )
+    df["close"] = df["close"].astype(float)
+    df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
+    DATA_DIR.mkdir(exist_ok=True)
+    df.to_csv(csv_path, index=False)
+    return df[["open_time", "close"]]

--- a/TradingBotTV/ml_optimizer/logger.py
+++ b/TradingBotTV/ml_optimizer/logger.py
@@ -1,0 +1,16 @@
+import logging
+
+
+def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+    """Return a configured :class:`logging.Logger` with *name*."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+            "%Y-%m-%d %H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger

--- a/TradingBotTV/ml_optimizer/requirements.txt
+++ b/TradingBotTV/ml_optimizer/requirements.txt
@@ -2,3 +2,4 @@ requests
 pandas
 numpy
 tradingview_ta
+aiohttp

--- a/TradingBotTV/ml_optimizer/rl_optimizer.py
+++ b/TradingBotTV/ml_optimizer/rl_optimizer.py
@@ -1,31 +1,48 @@
 """Simple reinforcement learning optimizer for RSI thresholds."""
 
-import json
 import random
+from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 
 from .data_fetcher import fetch_klines
 from .backtest import backtest_strategy
+from .logger import get_logger
+from .state_utils import (
+    load_state as load_json_state,
+    save_state as save_json_state,
+)
 
-STATE_PATH = 'rl_state.json'
+logger = get_logger(__name__)
+
+STATE_PATH = Path(__file__).with_name("rl_state.json")
 
 # Search space for RSI thresholds
 BUY_SPACE = list(range(20, 41, 2))
 SELL_SPACE = list(range(60, 81, 2))
 
 
-def load_state():
-    try:
-        with open(STATE_PATH, 'r') as f:
-            return json.load(f)
-    except FileNotFoundError:
-        return {}
+@dataclass
+class RLState:
+    """Internal state persisted between training runs."""
+
+    mean_buy: float = 30.0
+    std_buy: float = 5.0
+    mean_sell: float = 70.0
+    std_sell: float = 5.0
+    best_buy: int = 30
+    best_sell: int = 70
 
 
-def save_state(state):
-    with open(STATE_PATH, 'w') as f:
-        json.dump(state, f)
+def load_state() -> RLState:
+    """Load persisted :class:`RLState` from :data:`STATE_PATH`."""
+    return load_json_state(STATE_PATH, RLState)
+
+
+def save_state(state: RLState) -> None:
+    """Persist ``state`` to :data:`STATE_PATH`."""
+    save_json_state(STATE_PATH, state)
 
 
 def train(symbol, episodes=30, population=20, elite_frac=0.2, seed=None):
@@ -56,14 +73,14 @@ def train(symbol, episodes=30, population=20, elite_frac=0.2, seed=None):
 
     state = load_state()
 
-    mean_buy = state.get('mean_buy', 30.0)
-    std_buy = state.get('std_buy', 5.0)
-    mean_sell = state.get('mean_sell', 70.0)
-    std_sell = state.get('std_sell', 5.0)
+    mean_buy = state.mean_buy
+    std_buy = state.std_buy
+    mean_sell = state.mean_sell
+    std_sell = state.std_sell
 
-    df = fetch_klines(symbol, interval='1h', limit=500)
+    df = fetch_klines(symbol, interval="1h", limit=500)
     if df.empty:
-        print('No data fetched – aborting training')
+        logger.warning('No data fetched – aborting training')
         return int(round(mean_buy)), int(round(mean_sell))
 
     for _ in range(episodes):
@@ -88,21 +105,23 @@ def train(symbol, episodes=30, population=20, elite_frac=0.2, seed=None):
 
     best_buy = int(round(mean_buy))
     best_sell = int(round(mean_sell))
-    save_state({
-        'mean_buy': mean_buy,
-        'std_buy': std_buy,
-        'mean_sell': mean_sell,
-        'std_sell': std_sell,
-        'best_buy': best_buy,
-        'best_sell': best_sell,
-    })
-    print(f'Best params: {best_buy} {best_sell}')
+    save_state(
+        RLState(
+            mean_buy=mean_buy,
+            std_buy=std_buy,
+            mean_sell=mean_sell,
+            std_sell=std_sell,
+            best_buy=best_buy,
+            best_sell=best_sell,
+        )
+    )
+    logger.info('Best params: %s %s', best_buy, best_sell)
     return best_buy, best_sell
 
 
 if __name__ == '__main__':
     import sys
     if len(sys.argv) < 2:
-        print('Usage: python rl_optimizer.py SYMBOL')
+        logger.error('Usage: python rl_optimizer.py SYMBOL')
         sys.exit(1)
     train(sys.argv[1])

--- a/TradingBotTV/ml_optimizer/state_utils.py
+++ b/TradingBotTV/ml_optimizer/state_utils.py
@@ -1,0 +1,22 @@
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+import json
+from typing import Type, TypeVar
+
+T = TypeVar('T')
+
+
+def load_state(path: Path, cls: Type[T]) -> T:
+    """Load dataclass instance of type ``cls`` from ``path``."""
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return cls()  # type: ignore[arg-type]
+    return cls(**data)  # type: ignore[arg-type]
+
+
+def save_state(path: Path, state: T) -> None:
+    """Save dataclass ``state`` to ``path``."""
+    if not is_dataclass(state):
+        raise TypeError('state must be a dataclass instance')
+    path.write_text(json.dumps(asdict(state)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tradingbottv"
+version = "0.1.0"
+description = "Optimization utilities for BinanceTraderBot"
+requires-python = ">=3.8"
+authors = [
+    {name = "TradingBotTV"}
+]
+dependencies = [
+    "requests",
+    "aiohttp",
+    "pandas",
+    "numpy",
+    "tradingview_ta",
+]
+
+[project.optional-dependencies]
+test = ["pytest", "flake8"]
+
+[tool.setuptools.package-dir]
+"" = "TradingBotTV"


### PR DESCRIPTION
## Summary
- introduce reusable logger module
- add async `async_fetch_klines` and update fetch logic
- persist optimizer states via generic helpers
- read API keys from environment variables
- add GitHub Actions workflow and packaging metadata
- extend README with environment variable instructions

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8a83ebec8320943fa6b9b16fc6c9