### PR TITLE
Fix optimizer parsing and clean docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ Strategia łączy sygnały z interwałów 1m, 30m i 1h, filtruje trend na podsta
      ```powershell
      winget install Microsoft.DotNet.SDK.8
      ```
-1. Zainstaluj pakiet `.NET 8 SDK` (np. w systemie Ubuntu):
-   ```bash
-   sudo apt-get update
-   sudo apt-get install -y dotnet-sdk-8.0
-   ```
 2. Zainstaluj wymagane biblioteki Pythona:
    ```bash
    pip install -r TradingBotTV/ml_optimizer/requirements.txt

--- a/TradingBotTV/bot/OptimizerRunner.cs
+++ b/TradingBotTV/bot/OptimizerRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 using Newtonsoft.Json.Linq;
 namespace Bot
@@ -33,18 +34,16 @@ namespace Bot
                     Console.WriteLine("⚠️ Błędy optymalizacji: " + error);
 
                 // Parsujemy output, żeby uaktualnić config:
-                // Załóżmy, że output zawiera linię: BestParams: buy=30 sell=70
-                var lines = output.Split('\n');
-                foreach (var line in lines)
+                // Szukamy linii w formacie "Najlepsze parametry: Buy=30 Sell=70 PnL=..."
+                foreach (var line in output.Split('\n'))
                 {
                     if (line.StartsWith("Najlepsze parametry:"))
                     {
-                        var parts = line.Split(new string[] { "Buy=", "Sell=", "," }, StringSplitOptions.RemoveEmptyEntries);
-                        if(parts.Length >= 3)
+                        var match = Regex.Match(line, @"Buy=(\d+).*Sell=(\d+)");
+                        if (match.Success)
                         {
-                            int buyTh = int.Parse(parts[1].Trim());
-                            int sellTh = int.Parse(parts[2].Trim());
-
+                            int buyTh = int.Parse(match.Groups[1].Value);
+                            int sellTh = int.Parse(match.Groups[2].Value);
                             UpdateConfig(buyTh, sellTh);
                             Console.WriteLine($"♻️ Zaktualizowano ustawienia RSI: Buy={buyTh}, Sell={sellTh}");
                         }

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -50,15 +50,11 @@ Najważniejsze parametry znajdują się w pliku `TradingBotTV/config/settings.js
     "rsiBuyThreshold": 30,
     "rsiSellThreshold": 70,
     "stopLossPercent": 1.5,
-  "takeProfitPercent": 3.0,
-
-  "trailingStopPercent": 0.5,
-  "maxDrawdownPercent": 20,
-  "emaShortPeriod": 50,
-  "emaLongPeriod": 200
-
-  "trailingStopPercent": 0.5
-
+    "takeProfitPercent": 3.0,
+    "trailingStopPercent": 0.5,
+    "maxDrawdownPercent": 20,
+    "emaShortPeriod": 50,
+    "emaLongPeriod": 200
   },
   "websocket": {
     "binanceUrl": "wss://stream.binance.com:9443/ws",
@@ -73,10 +69,6 @@ Najważniejsze parametry znajdują się w pliku `TradingBotTV/config/settings.js
 - `rsiBuyThreshold` i `rsiSellThreshold` – progi RSI wykorzystywane w strategii.
 - `stopLossPercent` i `takeProfitPercent` – ustawienia SL/TP w procentach.
 - `trailingStopPercent` – wielkość trailing stopu aktualizowana po każdej zmianie ceny.
-- `maxDrawdownPercent` – maksymalny dopuszczalny spadek wartości portfela (w % od początkowego kapitału), po którego przekroczeniu handel zostaje automatycznie wstrzymany.
-- `emaShortPeriod` i `emaLongPeriod` – okresy obliczania krótkiej i długiej EMA używane w filtrze trendu.
-
-
 - `maxDrawdownPercent` – maksymalny dopuszczalny spadek wartości portfela (w % od początkowego kapitału), po którego przekroczeniu handel zostaje automatycznie wstrzymany.
 - `emaShortPeriod` i `emaLongPeriod` – okresy obliczania krótkiej i długiej EMA używane w filtrze trendu.
 

--- a/docs/repo_analysis.md
+++ b/docs/repo_analysis.md
@@ -17,17 +17,17 @@ TradingBotTV/ml_optimizer/auto_optimizer.py  -- simple optimizer storing model_s
 TradingBotTV/ml_optimizer/rl_optimizer.py    -- reinforcement-learning example
 ```
 
-No AGENTS.md file or special repository instructions were found.
+An `AGENTS.md` file defines basic contribution guidelines (tests must pass and `flake8` should report no errors).
 
 ### Testing
 The Python requirements install successfully, and the provided tests run without errors:
 
 ```
 pip install -r TradingBotTV/ml_optimizer/requirements.txt
-pytest -q TradingBotTV/ml_optimizer/tests/test_backtest.py
+pytest
 ```
 
-Result: **4 tests pass**
+Result: **10 tests pass**
 
 *(Compilation of the C# project wasn’t attempted because .NET tooling is absent in this environment.)*
 


### PR DESCRIPTION
## Summary
- parse optimizer output with regex and only update config on success
- remove repeated .NET installation step from the README
- note AGENTS instructions and full test count in docs/repo_analysis.md
- correct JSON example and bullet list in docs/README_pl.md

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `flake8`
- `pytest -q`
- `dotnet build TradingBotTV/bot/BinanceTraderBot.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3ef3bb18832096fa2daff5aa9151