### PR TITLE
Fix flake8 warnings and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ W katalogu projektu uruchom testy poleceniem:
 ```bash
 pytest
 ```
+Przed wysłaniem zmian uruchom również `flake8`, aby upewnić się, że kod spełnia
+standard PEP8:
+```bash
+flake8
+```
 
 
 ### Sygnały z TradingView

--- a/TradingBotTV/ml_optimizer/auto_optimizer.py
+++ b/TradingBotTV/ml_optimizer/auto_optimizer.py
@@ -1,4 +1,3 @@
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -82,7 +81,12 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Optimize RSI thresholds')
     parser.add_argument('symbol', help='Trading symbol')
-    parser.add_argument('--iterations', type=int, default=20, help='Number of tests')
+    parser.add_argument(
+        '--iterations',
+        type=int,
+        default=20,
+        help='Number of tests',
+    )
     parser.add_argument(
         '--log-level',
         default='INFO',

--- a/TradingBotTV/ml_optimizer/compare_strategies.py
+++ b/TradingBotTV/ml_optimizer/compare_strategies.py
@@ -1,5 +1,3 @@
-import sys
-
 from .data_fetcher import fetch_klines
 from .backtest import compare_strategies
 from .logger import get_logger
@@ -25,7 +23,11 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Compare strategies')
     parser.add_argument('symbol', help='Trading symbol')
-    parser.add_argument('--log-level', default='INFO', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
+    parser.add_argument(
+        '--log-level',
+        default='INFO',
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+    )
     args = parser.parse_args()
 
     logger.setLevel(args.log_level)

--- a/TradingBotTV/ml_optimizer/data_fetcher.py
+++ b/TradingBotTV/ml_optimizer/data_fetcher.py
@@ -11,7 +11,12 @@ logger = get_logger(__name__)
 DATA_DIR = Path(__file__).with_name('data')
 
 
-def fetch_klines(symbol: str, interval: str = "1h", limit: int = 1000, retries: int = 3):
+def fetch_klines(
+    symbol: str,
+    interval: str = "1h",
+    limit: int = 1000,
+    retries: int = 3,
+):
     """Return OHLC data for ``symbol``.
 
     When network calls fail ``retries`` times, cached CSV data is used if
@@ -30,7 +35,12 @@ def fetch_klines(symbol: str, interval: str = "1h", limit: int = 1000, retries: 
             data = response.json()
             break
         except requests.RequestException as e:
-            logger.error("Error fetching klines (attempt %s/%s): %s", attempt + 1, retries, e)
+            logger.error(
+                "Error fetching klines (attempt %s/%s): %s",
+                attempt + 1,
+                retries,
+                e,
+            )
             if attempt == retries - 1:
                 if csv_path.exists():
                     logger.info("Loading cached data from %s", csv_path)
@@ -86,7 +96,10 @@ async def async_fetch_klines(
             break
         except Exception as e:  # pragma: no cover - network failure
             logger.error(
-                "Error fetching klines (attempt %s/%s): %s", attempt + 1, retries, e
+                "Error fetching klines (attempt %s/%s): %s",
+                attempt + 1,
+                retries,
+                e,
             )
             if attempt == retries - 1:
                 if csv_path.exists():

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -89,6 +89,7 @@ włączania i wyłączania handlu. Możesz również podejrzeć ostatni log tran
 
 1. Zainstaluj zależności Pythona: `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
 2. Uruchom testy: `pytest`
+3. Sprawdź styl kodu: `flake8`
 
 Pliki w C# wymagają .NET 8. Informacje o budowaniu i uruchamianiu znajdują się w głównym pliku `README.md`.
 


### PR DESCRIPTION
## Summary
- clean up unused imports and long lines
- document flake8 in README and docs
- update Python scripts to satisfy style checker

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dce18704c8320bdcedcb50b1a15eb