### PR TITLE
Fix import duplication and stray parenthesis

### DIFF
--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -18,11 +18,6 @@ from .tradingview_auto_trader import (
 from .logger import get_logger
 from .monitor import record_metric
 from .network_utils import check_connectivity, async_check_connectivity
-from .network_utils import (
-    check_connectivity,
-    async_check_connectivity,
-)
-from .network_utils import check_connectivity
 
 __all__ = [
     "compute_rsi",

--- a/TradingBotTV/ml_optimizer/network_utils.py
+++ b/TradingBotTV/ml_optimizer/network_utils.py
@@ -65,6 +65,7 @@ def check_connectivity(url: str, retries: int = 3, timeout: int = 5) -> bool:
             time.sleep(2 ** attempt)
     return False
 
+
 async def async_check_connectivity(
     url: str,
     retries: int = 3,

--- a/TradingBotTV/ml_optimizer/tests/test_network_utils.py
+++ b/TradingBotTV/ml_optimizer/tests/test_network_utils.py
@@ -82,4 +82,3 @@ def test_async_check_connectivity_failure(monkeypatch):
     assert not asyncio.run(
         async_check_connectivity('http://example.com', retries=2)
     )
-    )


### PR DESCRIPTION
## Summary
- remove duplicate connectivity imports
- fix PEP8 blank line in `network_utils`
- remove unmatched parenthesis in tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1d2684088320a3b6dc0947c8d95e