### PR TITLE
Fix flake8 style error

### DIFF
--- a/TradingBotTV/ml_optimizer/tests/test_network_utils.py
+++ b/TradingBotTV/ml_optimizer/tests/test_network_utils.py
@@ -36,6 +36,7 @@ def test_check_connectivity_failure(monkeypatch):
     monkeypatch.setattr('requests.Session', lambda: session)
     assert not check_connectivity('http://example.com', retries=2)
 
+
 def test_async_check_connectivity_success(monkeypatch):
     class Session:
         async def __aenter__(self):


### PR DESCRIPTION
## Summary
- fix flake8 E302 error by inserting a blank line before `test_async_check_connectivity_success`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2133edc8832082a5f5a3e3884174