### PR TITLE
Update docs with network access note

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Najświeższe skrypty Pythona wykorzystują własny plik logów `TradingBotTV/ml
    # lub zainstaluj cały moduł
    pip install .
    ```
+   Jeśli instalacja zakończy się błędem z powodu zablokowanego dostępu do
+   `pypi.org` lub `files.pythonhosted.org`, ustaw zmienne środowiskowe proxy albo
+   zainstaluj pakiety z wcześniej pobranych plików `.whl`. Możesz sprawdzić
+   łączność poleceniem:
+   ```bash
+   python -m TradingBotTV.ml_optimizer.network_utils https://pypi.org
+   ```
 3. Zbuduj projekt C#:
    ```bash
    dotnet build TradingBotTV/bot/BinanceTraderBot.csproj
@@ -137,5 +144,23 @@ Komunikaty o błędach połączeń z API są wypisywane w konsoli, dzięki czemu
 ## Licencja
 
 Projekt jest dostępny na licencji MIT. Szczegóły znajdziesz w pliku [LICENSE](LICENSE).
+
+## Wkład w rozwój
+
+Przed wysłaniem zmian:
+
+1. Zainstaluj zależności Pythona:
+   ```bash
+   pip install -r TradingBotTV/ml_optimizer/requirements.txt
+   ```
+2. Upewnij się, że wszystkie testy przechodzą:
+   ```bash
+   pytest
+   ```
+3. Sprawdź styl kodu:
+   ```bash
+   flake8
+   ```
+4. W opisie PR napisz skrótowy opis zmian i dodaj informację, czy testy zakończyły się sukcesem.
 
 Więcej informacji znajdziesz w pliku [docs/README_pl.md](docs/README_pl.md).

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -98,8 +98,16 @@ włączania i wyłączania handlu. Możesz również podejrzeć ostatni log tran
 ## Jak uruchomić testy
 
 1. Zainstaluj zależności Pythona: `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
+   Jeśli pojawi się błąd związany z brakiem dostępu do `pypi.org`, skonfiguruj
+   proxy lub użyj lokalnych plików `.whl`. Łączność sprawdzisz poleceniem:
+   `python -m TradingBotTV.ml_optimizer.network_utils https://pypi.org`
 2. Uruchom testy: `pytest`
 3. Sprawdź styl kodu: `flake8`
 
 Pliki w C# wymagają .NET 8. Informacje o budowaniu i uruchamianiu znajdują się w głównym pliku `README.md`.
+
+## Licencja
+
+Projekt jest dostępny na licencji MIT. Treść licencji znajduje się w pliku
+[`LICENSE`](../LICENSE).
 


### PR DESCRIPTION
## Summary
- document how to handle blocked PyPI access during installation
- mention the network utils helper in Polish documentation

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_685f22425398832085f9e6f474d0b5a2