### PR TITLE
Add portfolio and order book modules with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ pod uwagę wzrost aktywności wolumenowej. Dodano obsługę trailing stop oraz
 dynamiczne dostosowanie wielkości pozycji w zależności od zmienności rynku.
 Bot samoczynnie wyłącza handel, gdy łączna strata przekroczy ustawiony próg `maxDrawdownPercent`.
 
+W folderze `ml_optimizer` pojawiły się moduły `risk`, `analytics` i `sentiment`,
+które umożliwiają obliczanie Kelly Criterion, Value at Risk, Bollinger Bands,
+oscylatora stochastycznego oraz prostą ocenę nastrojów inwestorów. Dodano
+również moduł `fundamental` z funkcjami pobierającymi dane z CoinMarketCap,
+CoinGecko, Messari i GitHuba. Moduł `sentiment` potrafi teraz pobrać wartość
+Crypto Fear & Greed Index i wskaźnik nastrojów z LunarCrush.
+Dodano też moduł `ml_models` z prostymi modelami predykcyjnymi oraz funkcję
+`backtest_tick_strategy` pozwalającą testować strategie na danych sekundowych
+z uwzględnieniem poślizgu i prowizji.
+Pojawiły się moduły `portfolio`, `orderbook`, `hedging` i `arbitrage`, które
+ułatwiają zarządzanie wieloma symbolami, analizę księgi zleceń w czasie
+rzeczywistym oraz zabezpieczanie pozycji kontraktami futures lub wyszukiwanie
+okazji arbitrażowych.
+
 Strategia łączy sygnały z interwałów 1m, 30m i 1h, filtruje trend na podstawie średnich EMA (50 i 200) i zapisuje logi do pliku `logs/bot.log`. Moduł `ml_optimizer` zawiera skrypty do optymalizacji parametrów i trenowania modelu RL (`rl_optimizer.py`) oraz porównywania strategii (`compare_strategies.py`).
 
 Najświeższe skrypty Pythona wykorzystują własny plik logów `TradingBotTV/ml_optimizer/state/ml_optimizer.log` (rotacja plików) oraz prosty moduł monitoringu zapisujący statystyki w `TradingBotTV/ml_optimizer/state/metrics.csv`. Operacje sieciowe (pobieranie danych, wysyłanie webhooków, klonowanie repozytoriów) są teraz powtarzane kilkukrotnie z rosnącym opóźnieniem, co zwiększa odporność na chwilowe problemy z siecią.
@@ -106,6 +120,14 @@ w środowiskach asynchronicznych.
 * `tradingview_auto_trader.py` – pobiera rekomendacje z TradingView i wysyła
   sygnały do lokalnego webhooka. Funkcja `async_auto_trade_from_tv` pozwala
   obsłużyć wiele symboli równolegle.
+* `ml_models.py` – proste modele predykcyjne (RandomForest) i optymalizacja
+  hiperparametrów
+* `backtest_tick_strategy` – testy na danych 1‑sekundowych z uwzględnieniem
+  opóźnień i kosztów transakcyjnych
+* `portfolio.py` – zarządzanie wieloma instrumentami jednocześnie
+* `orderbook.py` – obliczanie best bid/ask i wskaźnika przepływu zleceń
+* `hedging.py` – szacowanie wielkości pozycji zabezpieczającej
+* `arbitrage.py` – sprawdzanie różnic cen między giełdami
 
 Aby uruchomić test porównawczy strategii:
 ```bash
@@ -162,5 +184,15 @@ Przed wysłaniem zmian:
    flake8
    ```
 4. W opisie PR napisz skrótowy opis zmian i dodaj informację, czy testy zakończyły się sukcesem.
+
+### Źródła analizy fundamentalnej i sentymentu
+
+- CoinMarketCap, CoinGecko – ogólne dane rynkowe
+- Messari, Token Terminal – raporty i przychody projektów
+- GitHub – statystyki aktywności deweloperów
+- Certik, Quantstamp – status audytów smart kontraktów
+- Glassnode, CryptoQuant, Santiment – wskaźniki on‑chain i sentyment
+- Etherscan, Solscan – eksploratory blockchaina
+- Crypto Fear & Greed Index, LunarCrush – gotowe wskaźniki nastroju
 
 Więcej informacji znajdziesz w pliku [docs/README_pl.md](docs/README_pl.md).

--- a/TradingBotTV/AGENTS.md
+++ b/TradingBotTV/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS instructions for TradingBotTV package
+
+This directory houses the Python and C# sources for the bot.
+
+## Testing
+- Install dependencies from the repository root using `pip install -r TradingBotTV/ml_optimizer/requirements.txt`.
+- Run the Python test suite with `pytest`.
+
+## Style
+- Follow PEP8 guidelines; run `flake8` and ensure it reports no issues.
+- Keep commit messages clear and descriptive.
+
+## Pull Requests
+- Summarize changes and test results in the PR description.

--- a/TradingBotTV/bot/AGENTS.md
+++ b/TradingBotTV/bot/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS instructions for C# bot
+
+This directory contains the C# implementation of the trading bot.
+
+## Testing
+- Building or running tests for the C# project is optional in this environment, but ensure Python tests still pass.
+
+## Pull Requests
+- Describe any C# changes and confirm Python tests succeed.

--- a/TradingBotTV/ml_optimizer/AGENTS.md
+++ b/TradingBotTV/ml_optimizer/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS instructions for ml_optimizer
+
+This module contains optimization and backtesting utilities.
+
+## Testing
+- Install requirements using `pip install -r TradingBotTV/ml_optimizer/requirements.txt`.
+- Execute tests with `pytest` and ensure all pass.
+- Run `flake8` for style compliance.
+
+## Pull Requests
+- Provide a summary of changes and mention test results.

--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -16,6 +16,27 @@ from .tradingview_auto_trader import (
     auto_trade_from_tv,
     async_auto_trade_from_tv,
 )
+from .risk import kelly_fraction, value_at_risk
+from .fundamental import (
+    fetch_coinmarketcap_data,
+    fetch_coingecko_market_data,
+    fetch_messari_asset_metrics,
+    fetch_github_activity,
+)
+from .analytics import (
+    bollinger_bands,
+    stochastic_oscillator,
+    order_book_imbalance,
+)
+from .ml_models import (
+    train_predictive_model,
+    optimize_predictive_model,
+    backtest_tick_strategy,
+)
+from .portfolio import allocate_equal_weight, calculate_position_sizes
+from .orderbook import best_bid_ask, compute_order_flow_imbalance
+from .hedging import hedge_ratio
+from .arbitrage import price_spread
 from .logger import get_logger
 from .monitor import record_metric
 from .network_utils import check_connectivity, async_check_connectivity
@@ -38,4 +59,22 @@ __all__ = [
     "simulate_strategy",
     "auto_trade_from_tv",
     "async_auto_trade_from_tv",
+    "kelly_fraction",
+    "value_at_risk",
+    "fetch_coinmarketcap_data",
+    "fetch_coingecko_market_data",
+    "fetch_messari_asset_metrics",
+    "fetch_github_activity",
+    "bollinger_bands",
+    "stochastic_oscillator",
+    "order_book_imbalance",
+    "train_predictive_model",
+    "optimize_predictive_model",
+    "backtest_tick_strategy",
+    "allocate_equal_weight",
+    "calculate_position_sizes",
+    "best_bid_ask",
+    "compute_order_flow_imbalance",
+    "hedge_ratio",
+    "price_spread",
 ]

--- a/TradingBotTV/ml_optimizer/analytics.py
+++ b/TradingBotTV/ml_optimizer/analytics.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+
+def bollinger_bands(
+    series: pd.Series, window: int = 20, num_std: int = 2
+) -> pd.DataFrame:
+    """Return Bollinger Bands for ``series``."""
+    sma = series.rolling(window=window).mean()
+    std = series.rolling(window=window).std()
+    upper = sma + num_std * std
+    lower = sma - num_std * std
+    return pd.DataFrame({'sma': sma, 'upper': upper, 'lower': lower})
+
+
+def stochastic_oscillator(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    k_period: int = 14,
+    d_period: int = 3,
+) -> pd.DataFrame:
+    """Return Stochastic Oscillator %K and %D."""
+    lowest_low = low.rolling(window=k_period).min()
+    highest_high = high.rolling(window=k_period).max()
+    percent_k = 100 * (close - lowest_low) / (highest_high - lowest_low)
+    percent_d = percent_k.rolling(window=d_period).mean()
+    return pd.DataFrame({'%K': percent_k, '%D': percent_d})
+
+
+def order_book_imbalance(bids: pd.Series, asks: pd.Series) -> float:
+    """Return simple order book imbalance from bid/ask volumes."""
+    total_bid = bids.sum()
+    total_ask = asks.sum()
+    if total_bid + total_ask == 0:
+        return 0.0
+    return (total_bid - total_ask) / (total_bid + total_ask)

--- a/TradingBotTV/ml_optimizer/arbitrage.py
+++ b/TradingBotTV/ml_optimizer/arbitrage.py
@@ -1,0 +1,6 @@
+"""Utilities for simple price arbitrage calculations."""
+
+
+def price_spread(price_a: float, price_b: float) -> float:
+    """Return price difference between two markets."""
+    return price_a - price_b

--- a/TradingBotTV/ml_optimizer/backtest.py
+++ b/TradingBotTV/ml_optimizer/backtest.py
@@ -30,20 +30,28 @@ def backtest_strategy(
         price = df["close"].iloc[i]
 
         if position == 1:
-            if stop_loss_pct and price <= entry_price * (1 - stop_loss_pct / 100):
+            if stop_loss_pct and price <= entry_price * (
+                1 - stop_loss_pct / 100
+            ):
                 pnl += price - entry_price
                 position = 0
                 continue
-            if take_profit_pct and price >= entry_price * (1 + take_profit_pct / 100):
+            if take_profit_pct and price >= entry_price * (
+                1 + take_profit_pct / 100
+            ):
                 pnl += price - entry_price
                 position = 0
                 continue
         elif position == -1:
-            if stop_loss_pct and price >= entry_price * (1 + stop_loss_pct / 100):
+            if stop_loss_pct and price >= entry_price * (
+                1 + stop_loss_pct / 100
+            ):
                 pnl += entry_price - price
                 position = 0
                 continue
-            if take_profit_pct and price <= entry_price * (1 - take_profit_pct / 100):
+            if take_profit_pct and price <= entry_price * (
+                1 - take_profit_pct / 100
+            ):
                 pnl += entry_price - price
                 position = 0
                 continue

--- a/TradingBotTV/ml_optimizer/fundamental.py
+++ b/TradingBotTV/ml_optimizer/fundamental.py
@@ -1,0 +1,42 @@
+import os
+import requests
+
+
+def fetch_coinmarketcap_data(symbol: str, api_key: str | None = None) -> dict:
+    """Return latest market data for ``symbol`` from CoinMarketCap."""
+    api_key = api_key or os.getenv("COINMARKETCAP_API_KEY")
+    headers = {"X-CMC_PRO_API_KEY": api_key} if api_key else {}
+    url = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest"
+    params = {"symbol": symbol}
+    response = requests.get(url, headers=headers, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_coingecko_market_data(coin_id: str) -> dict:
+    """Return market data for ``coin_id`` from CoinGecko."""
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_messari_asset_metrics(asset: str) -> dict:
+    """Return asset metrics for ``asset`` from Messari."""
+    url = f"https://data.messari.io/api/v1/assets/{asset}/metrics"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_github_activity(repo: str) -> dict:
+    """Return basic GitHub repository statistics."""
+    url = f"https://api.github.com/repos/{repo}"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return {
+        "stars": data.get("stargazers_count", 0),
+        "forks": data.get("forks_count", 0),
+        "open_issues": data.get("open_issues_count", 0),
+    }

--- a/TradingBotTV/ml_optimizer/hedging.py
+++ b/TradingBotTV/ml_optimizer/hedging.py
@@ -1,0 +1,10 @@
+"""Simple hedging utilities."""
+
+
+def hedge_ratio(
+    spot_qty: float, spot_price: float, futures_price: float
+) -> float:
+    """Calculate futures quantity needed to hedge spot position."""
+    if spot_qty <= 0 or spot_price <= 0 or futures_price <= 0:
+        raise ValueError("invalid inputs")
+    return spot_qty * spot_price / futures_price

--- a/TradingBotTV/ml_optimizer/ml_models.py
+++ b/TradingBotTV/ml_optimizer/ml_models.py
@@ -1,0 +1,63 @@
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import GridSearchCV
+
+
+def _create_features(series: pd.Series) -> pd.DataFrame:
+    """Return simple return-based features for ``series``."""
+    return pd.DataFrame({
+        "ret_1": series.pct_change(),
+        "ret_5": series.pct_change(5),
+    }).fillna(0)
+
+
+def train_predictive_model(df: pd.DataFrame) -> RandomForestClassifier:
+    """Train a RandomForest model predicting next price direction."""
+    X = _create_features(df["close"])
+    y = (df["close"].shift(-1) > df["close"]).astype(int)[:-1]
+    X = X[:-1]
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(X, y)
+    return model
+
+
+def optimize_predictive_model(
+    df: pd.DataFrame,
+    param_grid: dict,
+) -> RandomForestClassifier:
+    """Grid search best parameters for a RandomForest model."""
+    X = _create_features(df["close"])
+    y = (df["close"].shift(-1) > df["close"]).astype(int)[:-1]
+    X = X[:-1]
+    base = RandomForestClassifier(random_state=42)
+    search = GridSearchCV(base, param_grid, cv=3, n_jobs=1)
+    search.fit(X, y)
+    return search.best_estimator_
+
+
+def backtest_tick_strategy(
+    df: pd.DataFrame,
+    model,
+    slippage: float = 0.0,
+    fee: float = 0.0,
+) -> float:
+    """Backtest predictions on tick/1-second data with slippage and fees."""
+    features = _create_features(df["price"])
+    preds = model.predict(features)
+    pnl = 0.0
+    position = 0
+    entry = 0.0
+    for i in range(len(preds) - 1):
+        price = df["price"].iloc[i]
+        if position == 0 and preds[i] == 1:
+            entry = price * (1 + slippage)
+            pnl -= entry * fee
+            position = 1
+        elif position == 1 and preds[i] == 0:
+            exit_price = price * (1 - slippage)
+            pnl += exit_price - entry - exit_price * fee
+            position = 0
+    if position == 1:
+        exit_price = df["price"].iloc[-1] * (1 - slippage)
+        pnl += exit_price - entry - exit_price * fee
+    return pnl

--- a/TradingBotTV/ml_optimizer/orderbook.py
+++ b/TradingBotTV/ml_optimizer/orderbook.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Tuple
+
+
+def best_bid_ask(
+    order_book: Dict[str, List[List[float]]],
+) -> Tuple[float, float]:
+    """Return best bid and ask price from order book snapshot."""
+    bids = order_book.get("bids")
+    asks = order_book.get("asks")
+    if not bids or not asks:
+        raise ValueError("order book must contain bids and asks")
+    best_bid = max(bids, key=lambda x: x[0])[0]
+    best_ask = min(asks, key=lambda x: x[0])[0]
+    return best_bid, best_ask
+
+
+def compute_order_flow_imbalance(
+    bids: List[float], asks: List[float]
+) -> float:
+    """Calculate order flow imbalance between bids and asks."""
+    bid_sum = sum(bids)
+    ask_sum = sum(asks)
+    total = bid_sum + ask_sum
+    if total == 0:
+        return 0.0
+    return (bid_sum - ask_sum) / total

--- a/TradingBotTV/ml_optimizer/portfolio.py
+++ b/TradingBotTV/ml_optimizer/portfolio.py
@@ -1,0 +1,21 @@
+from typing import Dict, List
+
+
+def allocate_equal_weight(
+    symbols: List[str], capital: float
+) -> Dict[str, float]:
+    """Allocate capital equally across all symbols."""
+    if not symbols or capital <= 0:
+        raise ValueError("symbols and capital must be provided")
+    allocation = capital / len(symbols)
+    return {sym: allocation for sym in symbols}
+
+
+def calculate_position_sizes(
+    prices: Dict[str, float], capital: float, risk_percent: float = 0.01
+) -> Dict[str, float]:
+    """Return position size for each symbol based on risk percentage."""
+    if not prices or capital <= 0 or risk_percent <= 0:
+        raise ValueError("invalid inputs")
+    alloc = capital * risk_percent / len(prices)
+    return {sym: alloc / price for sym, price in prices.items() if price > 0}

--- a/TradingBotTV/ml_optimizer/requirements.txt
+++ b/TradingBotTV/ml_optimizer/requirements.txt
@@ -3,3 +3,4 @@ pandas
 numpy
 tradingview_ta
 aiohttp
+scikit-learn

--- a/TradingBotTV/ml_optimizer/risk.py
+++ b/TradingBotTV/ml_optimizer/risk.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+
+def kelly_fraction(win_prob: float, win_loss_ratio: float) -> float:
+    """Return Kelly optimal fraction of capital to risk."""
+    if not 0 < win_prob < 1:
+        raise ValueError("win_prob must be in (0, 1)")
+    if win_loss_ratio <= 0:
+        raise ValueError("win_loss_ratio must be positive")
+    q = 1 - win_prob
+    return (win_prob / win_loss_ratio) - (q / win_loss_ratio)
+
+
+def value_at_risk(returns: pd.Series, level: float = 0.05) -> float:
+    """Return Value at Risk (VaR) at given confidence level."""
+    if not 0 < level < 1:
+        raise ValueError("level must be in (0, 1)")
+    if returns.empty:
+        raise ValueError("returns series is empty")
+    return -returns.quantile(level)

--- a/TradingBotTV/ml_optimizer/sentiment.py
+++ b/TradingBotTV/ml_optimizer/sentiment.py
@@ -1,0 +1,42 @@
+from collections import Counter
+from typing import Iterable
+import os
+import requests
+
+
+POSITIVE_WORDS = {"good", "great", "positive", "bull", "up"}
+NEGATIVE_WORDS = {"bad", "negative", "bear", "down", "fear"}
+
+
+def text_sentiment(texts: Iterable[str]) -> float:
+    """Return naive sentiment score in range [-1, 1]."""
+    counts = Counter()
+    for t in texts:
+        words = {w.lower().strip('.,!') for w in t.split()}
+        counts.update(words)
+    pos = sum(counts[w] for w in POSITIVE_WORDS)
+    neg = sum(counts[w] for w in NEGATIVE_WORDS)
+    total = pos + neg
+    if total == 0:
+        return 0.0
+    return (pos - neg) / total
+
+
+def fetch_fear_greed_index() -> int:
+    """Return the current value of the Crypto Fear & Greed Index."""
+    url = "https://api.alternative.me/fng/"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return int(data["data"][0]["value"])
+
+
+def fetch_lunarcrush_score(symbol: str, api_key: str | None = None) -> float:
+    """Return LunarCrush galaxy score for ``symbol``."""
+    api_key = api_key or os.getenv("LUNARCRUSH_API_KEY", "")
+    params = {"data": "galaxyScore", "symbol": symbol, "key": api_key}
+    url = "https://lunarcrush.com/api3"
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return float(data["data"][0]["galaxy_score"])

--- a/TradingBotTV/ml_optimizer/tests/test_analytics.py
+++ b/TradingBotTV/ml_optimizer/tests/test_analytics.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import analytics  # noqa: E402
+
+
+def test_bollinger_bands_shapes():
+    data = pd.Series(range(30))
+    bands = analytics.bollinger_bands(data, window=5)
+    assert set(bands.columns) == {"sma", "upper", "lower"}
+    assert len(bands) == 30
+
+
+def test_stochastic_oscillator_returns_values():
+    high = pd.Series([5, 6, 7, 8, 9])
+    low = pd.Series([1, 2, 3, 4, 5])
+    close = pd.Series([3, 4, 5, 6, 7])
+    osc = analytics.stochastic_oscillator(high, low, close, k_period=3)
+    assert "%K" in osc.columns and "%D" in osc.columns
+
+
+def test_order_book_imbalance_balanced():
+    bids = pd.Series([10, 20])
+    asks = pd.Series([10, 20])
+    assert analytics.order_book_imbalance(bids, asks) == 0

--- a/TradingBotTV/ml_optimizer/tests/test_arbitrage.py
+++ b/TradingBotTV/ml_optimizer/tests/test_arbitrage.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import arbitrage  # noqa: E402
+
+
+def test_price_spread():
+    spread = arbitrage.price_spread(101, 100)
+    assert spread == 1

--- a/TradingBotTV/ml_optimizer/tests/test_backtest.py
+++ b/TradingBotTV/ml_optimizer/tests/test_backtest.py
@@ -81,7 +81,10 @@ def test_backtest_strategy_stop_loss(monkeypatch):
     def dummy_rsi(series):
         return pd.Series([50, 20, 20, 20])
 
-    monkeypatch.setattr("TradingBotTV.ml_optimizer.backtest.compute_rsi", dummy_rsi)
+    monkeypatch.setattr(
+        "TradingBotTV.ml_optimizer.backtest.compute_rsi",
+        dummy_rsi,
+    )
 
     pnl = backtest_strategy(df, stop_loss_pct=5)
     assert pnl == -1

--- a/TradingBotTV/ml_optimizer/tests/test_fundamental.py
+++ b/TradingBotTV/ml_optimizer/tests/test_fundamental.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import fundamental  # noqa: E402
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_fetch_coinmarketcap_data(monkeypatch):
+    def dummy_get(url, headers=None, params=None, timeout=10):
+        payload = {"data": {"BTC": {"quote": {"USD": {"price": 100}}}}}
+        return DummyResponse(payload)
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    data = fundamental.fetch_coinmarketcap_data("BTC", api_key="x")
+    assert "data" in data
+
+
+def test_fetch_github_activity(monkeypatch):
+    def dummy_get(url, timeout=10):
+        payload = {
+            "stargazers_count": 1,
+            "forks_count": 2,
+            "open_issues_count": 0,
+        }
+        return DummyResponse(payload)
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    stats = fundamental.fetch_github_activity("octocat/Hello-World")
+    assert stats["stars"] == 1

--- a/TradingBotTV/ml_optimizer/tests/test_hedging.py
+++ b/TradingBotTV/ml_optimizer/tests/test_hedging.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import hedging  # noqa: E402
+
+
+def test_hedge_ratio():
+    ratio = hedging.hedge_ratio(1, 20000, 20050)
+    assert round(ratio, 6) == round(20000 / 20050, 6)

--- a/TradingBotTV/ml_optimizer/tests/test_ml_models.py
+++ b/TradingBotTV/ml_optimizer/tests/test_ml_models.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import (  # noqa: E402
+    train_predictive_model,
+    optimize_predictive_model,
+    backtest_tick_strategy,
+)
+
+
+def test_train_predictive_model_returns_estimator():
+    df = pd.DataFrame({"close": [1, 2, 3, 2, 3, 4, 5, 4, 5, 6]})
+    model = train_predictive_model(df)
+    assert hasattr(model, "predict")
+
+
+def test_optimize_predictive_model_returns_estimator():
+    df = pd.DataFrame({"close": [1, 2, 3, 2, 3, 4, 5, 4, 5, 6]})
+    model = optimize_predictive_model(df, {"n_estimators": [5, 10]})
+    assert hasattr(model, "predict")
+
+
+class DummyModel:
+    def predict(self, X):
+        return [1] * len(X)
+
+
+def test_backtest_tick_strategy_basic():
+    df = pd.DataFrame({"price": [1, 1.1, 1.2, 1.3]})
+    pnl = backtest_tick_strategy(df, DummyModel())
+    assert pnl > 0

--- a/TradingBotTV/ml_optimizer/tests/test_orderbook.py
+++ b/TradingBotTV/ml_optimizer/tests/test_orderbook.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import orderbook  # noqa: E402
+
+
+def test_best_bid_ask():
+    snapshot = {"bids": [[100, 1], [99, 2]], "asks": [[101, 1], [102, 2]]}
+    bid, ask = orderbook.best_bid_ask(snapshot)
+    assert bid == 100 and ask == 101
+
+
+def test_compute_order_flow_imbalance():
+    imbalance = orderbook.compute_order_flow_imbalance([1, 1], [1, 1])
+    assert imbalance == 0

--- a/TradingBotTV/ml_optimizer/tests/test_portfolio.py
+++ b/TradingBotTV/ml_optimizer/tests/test_portfolio.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import portfolio  # noqa: E402
+
+
+def test_allocate_equal_weight():
+    alloc = portfolio.allocate_equal_weight(["BTCUSDT", "ETHUSDT"], 1000)
+    assert alloc["BTCUSDT"] == 500 and alloc["ETHUSDT"] == 500
+
+
+def test_calculate_position_sizes():
+    prices = {"BTCUSDT": 20000, "ETHUSDT": 1000}
+    sizes = portfolio.calculate_position_sizes(prices, 10000, 0.1)
+    assert sizes["BTCUSDT"] > 0 and sizes["ETHUSDT"] > 0

--- a/TradingBotTV/ml_optimizer/tests/test_risk.py
+++ b/TradingBotTV/ml_optimizer/tests/test_risk.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import risk  # noqa: E402
+
+
+def test_kelly_fraction_valid():
+    frac = risk.kelly_fraction(0.6, 1)
+    assert 0 < frac < 1
+
+
+def test_value_at_risk_basic():
+    series = pd.Series([1, -2, 3, -4, 5])
+    var = risk.value_at_risk(series, level=0.2)
+    assert var > 0

--- a/TradingBotTV/ml_optimizer/tests/test_sentiment.py
+++ b/TradingBotTV/ml_optimizer/tests/test_sentiment.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import sentiment  # noqa: E402
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_fetch_fear_greed_index(monkeypatch):
+    def dummy_get(url, timeout=10):
+        return DummyResponse({"data": [{"value": "55"}]})
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    assert sentiment.fetch_fear_greed_index() == 55
+
+
+def test_fetch_lunarcrush_score(monkeypatch):
+    def dummy_get(url, params=None, timeout=10):
+        return DummyResponse({"data": [{"galaxy_score": 67.0}]})
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    score = sentiment.fetch_lunarcrush_score("BTC")
+    assert score == 67.0

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS instructions for documentation
+
+Any changes in this directory should keep wording clear and concise.
+
+## Testing
+- After editing documentation, run `pytest` to ensure no code changes broke tests.
+
+## Pull Requests
+- Summarize documentation updates and confirm test results in the PR.

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -32,6 +32,10 @@ Poniżej znajduje się opis plików i katalogów w repozytorium. Wszystkie nazwy
 - `tradingview_auto_trader.py` – pobieranie rekomendacji z TradingView
   i wysyłanie sygnałów do lokalnego webhooka. Funkcja `async_auto_trade_from_tv`
   umożliwia obsługę wielu symboli równolegle.
+- `portfolio.py` – alokacja kapitału na wiele par jednocześnie
+- `orderbook.py` – analiza order book i obliczanie best bid/ask
+- `hedging.py` – obliczanie wielkości pozycji zabezpieczającej
+- `arbitrage.py` – prosty kalkulator różnic cen
 - `logger.py` – wspólne funkcje logujące zapisujące zdarzenia w `state/ml_optimizer.log`.
 - `monitor.py` – prosty rejestrator metryk tworzący plik `state/metrics.csv`.
 - `network_utils.py` – sprawdzanie dostępu do wybranych adresów URL (funkcje


### PR DESCRIPTION
## Summary
- extend optimizer package with modules for portfolio management, order book analysis, hedging and arbitrage
- export new helpers via `__init__`
- document new features in both READMEs
- add unit tests for the new modules

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f2cf22df08320881aae56e0fdbaca