### PR TITLE
Fix duplicate unlink and EOF newline in test_data_fetcher

### DIFF
--- a/TradingBotTV/ml_optimizer/tests/test_data_fetcher.py
+++ b/TradingBotTV/ml_optimizer/tests/test_data_fetcher.py
@@ -40,4 +40,3 @@ def test_fetch_coingecko_market_chart(monkeypatch):
     )
     if csv_path.exists():
         csv_path.unlink()
-        csv_path.unlink()


### PR DESCRIPTION
## Summary
- remove duplicate `csv_path.unlink()` in `test_data_fetcher`
- ensure the file ends with a newline

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f423f6b6c8320a0aaf0550c0093c2