### PR TITLE
Refactor connectivity helper and update TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ Bot nasłuchuje na `http://localhost:5000/webhook` i uruchamia proces samouczeni
 `StrategyEngine` co minutę pobiera bieżące notowania i samodzielnie składa zlecenia. Wysoki wolumen zwiększa szansę na wygenerowanie sygnału.
 Bot nawiązuje także stałe połączenie WebSocket z Binance, a opcjonalnie z TradingView, jeśli podasz adres w konfiguracji.
 
-Uruchomiono również panel na `http://localhost:5001`, który dzięki bibliotece Dash
-prezentuje wiele wykresów z modułu `ml_optimizer`. W panelu można podać klucze API,
-zdefiniować dodatkowe linki potrzebne botowi, obserwować aktualny status i jednym
-przyciskiem włączyć lub zatrzymać handel.
+Uruchomiony jest też prosty panel pod adresem `http://localhost:5001`.
+Wyświetla on PnL, łączną wielkość pozycji oraz przycisk start/stop.
+Panel nie korzysta z biblioteki Dash i nie pozwala na wpisanie kluczy API ani
+linków – służy jedynie do szybkiego podglądu i włączania bądź wyłączania handlu.
 
 Proces optymalizacji (`auto_optimizer.py` lub `rl_optimizer.py`) wykonuje się automatycznie co 15, 30 i 60 minut, zapisując najlepsze parametry w `model_state.json`.
 
@@ -170,9 +170,9 @@ standard PEP8:
 ```bash
 flake8
 ```
-Zestaw testów obejmuje także integrację pomiędzy modułem C# a skryptem
-`auto_optimizer.py`, dzięki czemu weryfikujemy poprawne wczytywanie
-zoptymalizowanych parametrów.
+Zestaw testów sprawdza m.in. czy wyniki `auto_optimizer.py` są poprawnie
+wczytywane do pliku konfiguracyjnego. Testy nie uruchamiają jednak bezpośrednio
+kodu w C# – weryfikacja odbywa się wyłącznie po stronie Pythona.
 
 
 ### Sygnały z TradingView
@@ -220,7 +220,7 @@ Zobacz także plik [TODO.md](TODO.md) zawierający listę planowanych usprawnie�
 ### Źródła analizy fundamentalnej i sentymentu
 
 - CoinMarketCap, CoinGecko – ogólne dane rynkowe
-- Messari, Token Terminal – raporty i przychody projektów
+- Messari – raporty i przychody projektów
 - GitHub – statystyki aktywności deweloperów
 - Certik, Quantstamp – status audytów smart kontraktów
 - Glassnode, CryptoQuant, Santiment – wskaźniki on‑chain i sentyment

--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,18 @@
 # TODO List
 
-This project is still under active development. Some improvements that could be implemented:
+This project is still under active development. The following tasks remain or could improve the bot:
 
-- Implement real-time order book feed via Binance WebSocket API for more precise HFT signals. **(done)**
-- Expand `hft.py` with latency monitoring and faster execution helpers. **(done)**
-- Extend the options module with Greeks calculations and advanced portfolio management. **(done)**
-- Add persistent database storage for trades and metrics. **(done)**
-- Build a Dash web panel with additional charts. **(done)**
-- Extend the web panel with API credential fields and start/stop controls. **(done)**
-- Implement adaptive stop-loss and take-profit using ATR. **(done)**
-- Support extended TradingView webhook fields and multi-strategy execution. **(done)**
-- Cache fundamental data regularly for transaction filters. **(done)**
-- Send Telegram alerts for executed trades and optimizer changes. **(done)**
-- Add deep reinforcement learning examples for adaptive strategies. **(done)**
-- Create visualizations of performance metrics and risk indicators. **(done)**
-- Write integration tests that cover the interaction between the C# bot and Python optimizer. **(done)**
+- Integrate real-time order book feed from Binance into the trading engine for more precise HFT signals.
+- Expand `hft.py` with latency monitoring and faster execution helpers.
+- Link the `database` module with the C# bot to store trades and metrics persistently.
+- Provide an optional Dash web panel with additional charts and API credential fields.
+- Implement adaptive stop-loss and take-profit using ATR.
+- Support extended TradingView webhook fields and multi-strategy execution.
+- Regularly cache fundamental data for transaction filters.
+- Send Telegram alerts for executed trades and optimizer changes.
+- Add deep reinforcement learning examples for adaptive strategies.
+- Create visualizations of performance metrics and risk indicators.
+- Write integration tests that cover the interaction between the C# bot and Python optimizer.
+- Add a paper-trading mode and multi-exchange support.
 
 Contributions are welcome!

--- a/TradingBotTV/ml_optimizer/network_utils.py
+++ b/TradingBotTV/ml_optimizer/network_utils.py
@@ -19,29 +19,17 @@ def check_connectivity(url: str, retries: int = 3, timeout: int = 5) -> bool:
     The request is retried ``retries`` times on failures. Only a HEAD
     request is sent to keep traffic minimal.
     """
+    adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=retries,
+            backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["HEAD", "GET"],
+        )
+    )
     with requests.Session() as session:
-        session.mount(
-            "http://",
-            HTTPAdapter(
-                max_retries=Retry(
-                    total=retries,
-                    backoff_factor=1,
-                    status_forcelist=[500, 502, 503, 504],
-                    allowed_methods=["HEAD", "GET"],
-                )
-            ),
-        )
-        session.mount(
-            "https://",
-            HTTPAdapter(
-                max_retries=Retry(
-                    total=retries,
-                    backoff_factor=1,
-                    status_forcelist=[500, 502, 503, 504],
-                    allowed_methods=["HEAD", "GET"],
-                )
-            ),
-        )
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
 
         for attempt in range(retries):
             try:


### PR DESCRIPTION
## Summary
- refactor check_connectivity to reuse a single HTTP adapter
- clean up TODO list and add new improvement ideas

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_68639e9d087c8320a50da3a1fc6b6da5