### PR TITLE
Add dependency verification steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,10 @@
 
 ## Testing
 - Install Python dependencies with `pip install -r TradingBotTV/ml_optimizer/requirements.txt`.
-- Run tests using `pytest`.
-- Ensure all tests pass before committing any changes.
+- Verify that `pandas`, `numpy`, `tensorflow` and `flake8` are installed using
+  `pip show pandas numpy tensorflow flake8`.
+- Run tests using `pytest` and ensure they all pass before committing any
+  changes.
 
 ## Style
 - Follow PEP8 guidelines; `flake8` should report no errors.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,20 @@ Repozytorium zawiera także moduły `execution` (TWAP, VWAP), `hft` z prostymi
 sygnałami z orderbooka oraz `options` wykorzystujący model Black-Scholes i
 strategię straddle. W `ml_models` dostępna jest funkcja `train_deep_learning_model`.
 Dodano też skrypt `deep_rl_examples.py` prezentujący zastosowanie głębokiego RL
-do adaptacyjnych strategii handlu.
+do adaptacyjnych strategii handlu. Moduł `advanced_rl.py` pozwala trenować
+sieci LSTM i DQN w trybie online.
+Najnowsze funkcje obejmują wyliczanie wielkości pozycji na podstawie Value at
+Risk oraz inteligentne modyfikowanie zleceń limit dzięki modułowi
+`order_manager`.
+Pojawił się także moduł `strategies` z prostymi przykładami grid tradingu, DCA,
+scalpingu oraz arbitrażu. Funkcja `choose_strategy` potrafi automatycznie dobrać
+odpowiednią metodę w zależności od zmienności rynku i rozpiętości cen.
 
 Strategia łączy sygnały z interwałów 1m, 30m i 1h, filtruje trend na podstawie średnich EMA (50 i 200) i zapisuje logi do pliku `logs/bot.log`. Moduł `ml_optimizer` zawiera skrypty do optymalizacji parametrów i trenowania modelu RL (`rl_optimizer.py`) oraz porównywania strategii (`compare_strategies.py`).
 
 Najświeższe skrypty Pythona wykorzystują własny plik logów `TradingBotTV/ml_optimizer/state/ml_optimizer.log` (rotacja plików) oraz prosty moduł monitoringu zapisujący statystyki w `TradingBotTV/ml_optimizer/state/metrics.csv`. Operacje sieciowe (pobieranie danych, wysyłanie webhooków, klonowanie repozytoriów) są teraz powtarzane kilkukrotnie z rosnącym opóźnieniem, co zwiększa odporność na chwilowe problemy z siecią.
+
+Wprowadzono również moduł `paper_trading`, który pozwala na testowanie strategii na koncie wirtualnym bez ryzyka utraty kapitału. W zestawie testów pojawiły się scenariusze stresowe zapisujące kilkadziesiąt transakcji przy użyciu `db_cli`, co ułatwia weryfikację poprawności integracji Pythona z częścią C#.
 
 
 
@@ -144,6 +153,7 @@ w środowiskach asynchronicznych.
   opóźnień i kosztów transakcyjnych
 * `portfolio.py` – zarządzanie wieloma instrumentami jednocześnie
 * `orderbook.py` – obliczanie best bid/ask i wskaźnika przepływu zleceń
+* `order_manager.py` – automatyczne ustalanie i aktualizacja zleceń limit
 * `hedging.py` – szacowanie wielkości pozycji zabezpieczającej
 * `arbitrage.py` – sprawdzanie różnic cen między giełdami
 * `execution.py` – algorytmy TWAP i VWAP
@@ -152,10 +162,14 @@ w środowiskach asynchronicznych.
 * `websocket_orderbook.py` – kanał WebSocket z pełnym orderbookiem
 * `visualizer.py` – wizualizacja statystyk z `monitor.py` oraz ryzyka portfela
 * `database.py` – zapisywanie transakcji i metryk w bazie SQLite/PostgreSQL
-* `web_panel.py` – panel Dash z wykresami wyników i formularzem do wpisania kluczy API oraz przyciskiem start/stop
+* `web_panel.py` – panel Dash z wykresami wyników,
+  dodatkowymi wskaźnikami ryzyka oraz formularzem do wpisania kluczy API
+  i przyciskiem start/stop
 * `signal_handler.py` – rozszerzona obsługa sygnałów TradingView
 * `alerts.py` – powiadomienia Telegram o zleceniach i błędach
 * `deep_rl_examples.py` – przykładowe algorytmy głębokiego RL do adaptacyjnych strategii
+* `advanced_rl.py` – sieci LSTM i prosty DQN z trybem online
+* `strategies.py` – grid trading, DCA, scalping i wybór najlepszej techniki
 
 Aby uruchomić test porównawczy strategii:
 ```bash
@@ -206,6 +220,8 @@ Przed wysłaniem zmian:
    ```bash
    pip install -r TradingBotTV/ml_optimizer/requirements.txt
    pip install flake8
+   # sprawdź czy podstawowe pakiety zostały zainstalowane
+   pip show pandas numpy tensorflow flake8
    ```
 2. Upewnij się, że wszystkie testy przechodzą:
    ```bash

--- a/TradingBotTV/ml_optimizer/AGENTS.md
+++ b/TradingBotTV/ml_optimizer/AGENTS.md
@@ -4,6 +4,8 @@ This module contains optimization and backtesting utilities.
 
 ## Testing
 - Install requirements using `pip install -r TradingBotTV/ml_optimizer/requirements.txt`.
+- Confirm that `pandas`, `numpy`, `tensorflow` and `flake8` are available with
+  `pip show pandas numpy tensorflow flake8`.
 - Execute tests with `pytest` and ensure all pass.
 - Run `flake8` for style compliance.
 

--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -21,6 +21,7 @@ from .risk import (
     value_at_risk,
     adaptive_stop_levels,
     max_drawdown,
+    position_size_from_var,
 )
 from .fundamental import (
     fetch_coinmarketcap_data,
@@ -46,9 +47,16 @@ from .portfolio import (
     calculate_position_sizes,
     risk_parity_weights,
 )
+from .order_manager import limit_price_from_spread, adjust_order_price
 from .orderbook import best_bid_ask, compute_order_flow_imbalance
 from .hedging import hedge_ratio
 from .arbitrage import price_spread
+from .strategies import (
+    grid_levels,
+    dca_schedule,
+    scalp_signal,
+    choose_strategy,
+)
 from .logger import get_logger
 from .monitor import record_metric
 from .network_utils import check_connectivity, async_check_connectivity
@@ -145,4 +153,11 @@ __all__ = [
     "max_drawdown",
     "deep_q_learning_example",
     "policy_gradient_example",
+    "position_size_from_var",
+    "limit_price_from_spread",
+    "adjust_order_price",
+    "grid_levels",
+    "dca_schedule",
+    "scalp_signal",
+    "choose_strategy",
 ]

--- a/TradingBotTV/ml_optimizer/advanced_rl.py
+++ b/TradingBotTV/ml_optimizer/advanced_rl.py
@@ -1,0 +1,88 @@
+"""Advanced reinforcement learning utilities using LSTM and DQN."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+from tensorflow import keras
+from tensorflow.keras import layers
+
+
+@dataclass
+class LSTMTrendModel:
+    model: keras.Model
+
+    @classmethod
+    def create(cls, window: int = 10) -> "LSTMTrendModel":
+        inputs = keras.Input(shape=(window, 1))
+        x = layers.LSTM(16, activation="tanh")(inputs)
+        outputs = layers.Dense(1)(x)
+        model = keras.Model(inputs, outputs)
+        model.compile(optimizer="adam", loss="mse")
+        return cls(model)
+
+    def fit(self, prices: pd.Series, epochs: int = 3) -> None:
+        if len(prices) <= self.model.input_shape[1]:
+            raise ValueError("price series too short")
+        window = self.model.input_shape[1]
+        X = []
+        y = []
+        for i in range(len(prices) - window):
+            X.append(prices.iloc[i: i + window].values)
+            y.append(prices.iloc[i + window])
+        X = np.array(X)[..., None]
+        y = np.array(y)
+        self.model.fit(X, y, epochs=epochs, verbose=0)
+
+    def predict_next(self, window_prices: Iterable[float]) -> float:
+        arr = np.array(window_prices, dtype=float)[None, :, None]
+        return float(self.model.predict(arr, verbose=0)[0, 0])
+
+
+class OnlineRLTrainer:
+    """Simple online trainer adjusting model as new data arrives."""
+
+    def __init__(
+        self, model: LSTMTrendModel, update_interval: int = 10
+    ) -> None:
+        self.model = model
+        self.update_interval = update_interval
+        self.buffer: list[float] = []
+
+    def process_price(self, price: float) -> float | None:
+        self.buffer.append(price)
+        if len(self.buffer) >= self.update_interval:
+            series = pd.Series(self.buffer)
+            self.model.fit(series)
+            self.buffer = self.buffer[-self.model.model.input_shape[1]:]
+        if len(self.buffer) >= self.model.model.input_shape[1]:
+            return self.model.predict_next(
+                self.buffer[-self.model.model.input_shape[1]:]
+            )
+        return None
+
+
+def dqn_training_example(
+    states: np.ndarray,
+    actions: np.ndarray,
+    rewards: np.ndarray,
+    episodes: int = 5,
+) -> keras.Model:
+    """Train a minimal DQN on provided data."""
+    num_features = states.shape[1]
+    model = keras.Sequential([
+        layers.Dense(32, activation="relu", input_shape=(num_features,)),
+        layers.Dense(32, activation="relu"),
+        layers.Dense(actions.max() + 1, activation="linear"),
+    ])
+    model.compile(optimizer=keras.optimizers.Adam(0.001), loss="mse")
+    for _ in range(episodes):
+        q_values = model.predict(states, verbose=0)
+        target = q_values.copy()
+        for i, a in enumerate(actions):
+            target[i, a] = rewards[i]
+        model.fit(states, target, epochs=1, verbose=0)
+    return model

--- a/TradingBotTV/ml_optimizer/order_manager.py
+++ b/TradingBotTV/ml_optimizer/order_manager.py
@@ -1,0 +1,47 @@
+"""Helpers for limit order management based on bid/ask spreads."""
+
+from __future__ import annotations
+
+
+def limit_price_from_spread(
+    best_bid: float,
+    best_ask: float,
+    side: str,
+    spread_pct: float = 0.25,
+) -> float:
+    """Return limit price placed inside the spread.
+
+    ``spread_pct`` is a fraction of the spread added or subtracted from the
+    bid/ask price. ``side`` must be ``"buy"`` or ``"sell"``.
+    """
+    if best_ask <= best_bid:
+        raise ValueError("ask must be greater than bid")
+    if not 0 <= spread_pct <= 1:
+        raise ValueError("spread_pct must be between 0 and 1")
+    spread = best_ask - best_bid
+    if side == "buy":
+        return min(best_bid + spread * spread_pct, best_ask)
+    if side == "sell":
+        return max(best_ask - spread * spread_pct, best_bid)
+    raise ValueError("side must be 'buy' or 'sell'")
+
+
+def adjust_order_price(
+    current_price: float,
+    best_bid: float,
+    best_ask: float,
+    side: str,
+    threshold_pct: float = 0.1,
+) -> float:
+    """Return updated order price when spread widens significantly."""
+    target = limit_price_from_spread(
+        best_bid,
+        best_ask,
+        side,
+        threshold_pct,
+    )
+    if side == "buy" and target > current_price:
+        return target
+    if side == "sell" and target < current_price:
+        return target
+    return current_price

--- a/TradingBotTV/ml_optimizer/paper_trading.py
+++ b/TradingBotTV/ml_optimizer/paper_trading.py
@@ -1,0 +1,29 @@
+class PaperAccount:
+    """Simple paper trading account."""
+
+    def __init__(self, balance: float):
+        if balance < 0:
+            raise ValueError("balance must be non-negative")
+        self.balance = balance
+        self.positions = {}
+
+    def execute_order(self, symbol: str, side: str, qty: float, price: float):
+        if qty <= 0 or price <= 0:
+            raise ValueError("qty and price must be positive")
+        if side not in ("BUY", "SELL"):
+            raise ValueError("side must be BUY or SELL")
+        cost = qty * price
+        if side == "BUY":
+            if cost > self.balance:
+                raise ValueError("insufficient balance")
+            self.balance -= cost
+            self.positions[symbol] = self.positions.get(symbol, 0.0) + qty
+        else:
+            if self.positions.get(symbol, 0.0) < qty:
+                raise ValueError("insufficient position")
+            self.balance += cost
+            self.positions[symbol] -= qty
+        return {"symbol": symbol, "side": side, "qty": qty, "price": price}
+
+    def get_position(self, symbol: str) -> float:
+        return self.positions.get(symbol, 0.0)

--- a/TradingBotTV/ml_optimizer/requirements.txt
+++ b/TradingBotTV/ml_optimizer/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 scipy
 matplotlib
 dash
+tensorflow==2.16.2

--- a/TradingBotTV/ml_optimizer/risk.py
+++ b/TradingBotTV/ml_optimizer/risk.py
@@ -55,3 +55,25 @@ def adaptive_stop_levels(
     stop_loss = last_price - stop_factor * atr
     take_profit = last_price + take_factor * atr
     return {"stop_loss": stop_loss, "take_profit": take_profit}
+
+
+def position_size_from_var(
+    returns: pd.Series,
+    capital: float,
+    var_limit: float = 0.02,
+    level: float = 0.05,
+) -> float:
+    """Return position size constrained by VaR.
+
+    ``var_limit`` expresses the fraction of ``capital`` that may be lost with
+    the given confidence level.
+    """
+    if capital <= 0:
+        raise ValueError("capital must be positive")
+    if not 0 < var_limit < 1:
+        raise ValueError("var_limit must be in (0, 1)")
+    var = value_at_risk(returns, level=level)
+    if var <= 0:
+        raise ValueError("returns must yield positive VaR")
+    fraction = min(var_limit / var, 1.0)
+    return capital * fraction

--- a/TradingBotTV/ml_optimizer/strategies.py
+++ b/TradingBotTV/ml_optimizer/strategies.py
@@ -1,0 +1,52 @@
+"""Basic trading strategies and a simple selector."""
+
+from __future__ import annotations
+
+from typing import Sequence, List
+
+
+def grid_levels(price: float, step: float, levels: int) -> List[float]:
+    """Return buy and sell price levels around ``price``.
+
+    The function generates symmetric levels above and below ``price`` spaced by
+    ``step``. ``levels`` must be positive.
+    """
+    if step <= 0 or levels <= 0:
+        raise ValueError("step and levels must be positive")
+    return [
+        price + step * i if i > 0 else price - step * (-i)
+        for i in range(-levels, levels + 1)
+        if i != 0
+    ]
+
+
+def dca_schedule(amount: float, periods: int) -> List[float]:
+    """Return equal investment amounts for dollar-cost averaging."""
+    if periods <= 0 or amount <= 0:
+        raise ValueError("amount and periods must be positive")
+    slice_amt = amount / periods
+    return [slice_amt for _ in range(periods)]
+
+
+def scalp_signal(prices: Sequence[float], window: int = 3) -> int:
+    """Return 1 to buy, -1 to sell or 0 to hold based on a simple MA cross."""
+    if len(prices) <= window:
+        raise ValueError("not enough price data")
+    ma = sum(prices[-window - 1:-1]) / window
+    last = prices[-1]
+    if last > ma * 1.001:
+        return 1
+    if last < ma * 0.999:
+        return -1
+    return 0
+
+
+def choose_strategy(volatility: float, spread: float) -> str:
+    """Select trading strategy based on market conditions."""
+    if spread > 0.5:
+        return "arbitrage"
+    if volatility > 0.05:
+        return "scalping"
+    if volatility > 0.02:
+        return "grid"
+    return "dca"

--- a/TradingBotTV/ml_optimizer/tests/test_advanced_rl.py
+++ b/TradingBotTV/ml_optimizer/tests/test_advanced_rl.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer.advanced_rl import (  # noqa: E402
+    LSTMTrendModel,
+    OnlineRLTrainer,
+    dqn_training_example,
+)
+
+
+def test_lstm_trend_model_train_and_predict():
+    prices = pd.Series(np.linspace(1, 2, 20))
+    model = LSTMTrendModel.create(window=5)
+    model.fit(prices, epochs=1)
+    pred = model.predict_next(prices.iloc[-5:])
+    assert isinstance(pred, float)
+
+
+def test_online_rl_trainer_runs():
+    prices = np.linspace(1, 2, 15)
+    trainer = OnlineRLTrainer(
+        LSTMTrendModel.create(window=3), update_interval=5
+    )
+    out = None
+    for p in prices:
+        out = trainer.process_price(float(p))
+    assert out is not None
+
+
+def test_dqn_training_example_runs():
+    states = np.random.rand(10, 4)
+    actions = np.random.randint(0, 2, size=10)
+    rewards = np.random.rand(10)
+    model = dqn_training_example(states, actions, rewards, episodes=1)
+    pred = model.predict(states[:1], verbose=0)
+    assert pred.shape == (1, 2)

--- a/TradingBotTV/ml_optimizer/tests/test_db_cli_stress.py
+++ b/TradingBotTV/ml_optimizer/tests/test_db_cli_stress.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import sqlite3
+import subprocess
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+
+
+def _run_cli(args, env):
+    cmd = [sys.executable, '-m', 'TradingBotTV.ml_optimizer.db_cli'] + args
+    subprocess.run(cmd, check=True, env=env)
+
+
+def test_db_cli_handles_many_trades(tmp_path):
+    db = tmp_path / 'db.sqlite'
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(ROOT_DIR)
+    _run_cli(['init', '--path', str(db)], env)
+    for i in range(50):
+        _run_cli([
+            'trade', f'2024-01-01T00:00:{i:02d}', 'BTCUSDT', 'BUY', '1', '100',
+            '--path', str(db)
+        ], env)
+    with sqlite3.connect(db) as conn:
+        count = conn.execute('SELECT COUNT(*) FROM trades').fetchone()[0]
+    assert count == 50

--- a/TradingBotTV/ml_optimizer/tests/test_order_manager.py
+++ b/TradingBotTV/ml_optimizer/tests/test_order_manager.py
@@ -1,0 +1,14 @@
+from TradingBotTV.ml_optimizer import (
+    limit_price_from_spread,
+    adjust_order_price,
+)
+
+
+def test_limit_price_from_spread_buy():
+    price = limit_price_from_spread(100.0, 101.0, "buy", 0.5)
+    assert 100.0 < price <= 101.0
+
+
+def test_adjust_order_price_no_change():
+    new_price = adjust_order_price(100.5, 100.0, 101.0, "buy", 0.1)
+    assert new_price >= 100.5

--- a/TradingBotTV/ml_optimizer/tests/test_paper_trading.py
+++ b/TradingBotTV/ml_optimizer/tests/test_paper_trading.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer.paper_trading import PaperAccount  # noqa: E402
+
+
+def test_buy_and_sell_updates_balance_and_position():
+    account = PaperAccount(100)
+    account.execute_order("BTCUSDT", "BUY", 1, 10)
+    assert account.balance == 90
+    assert account.get_position("BTCUSDT") == 1
+    account.execute_order("BTCUSDT", "SELL", 1, 12)
+    assert account.balance == 102
+    assert account.get_position("BTCUSDT") == 0
+
+
+def test_stress_many_orders():
+    account = PaperAccount(1000)
+    price = 5
+    for _ in range(50):
+        account.execute_order("ETHUSDT", "BUY", 1, price)
+        account.execute_order("ETHUSDT", "SELL", 1, price)
+    assert account.balance == 1000
+    assert account.get_position("ETHUSDT") == 0

--- a/TradingBotTV/ml_optimizer/tests/test_risk.py
+++ b/TradingBotTV/ml_optimizer/tests/test_risk.py
@@ -24,3 +24,9 @@ def test_value_at_risk_basic():
     series = pd.Series([1, -2, 3, -4, 5])
     var = risk.value_at_risk(series, level=0.2)
     assert var > 0
+
+
+def test_position_size_from_var():
+    returns = pd.Series([0.01, -0.02, 0.015, -0.01])
+    size = risk.position_size_from_var(returns, capital=1000, var_limit=0.02)
+    assert 0 < size <= 1000

--- a/TradingBotTV/ml_optimizer/tests/test_strategies.py
+++ b/TradingBotTV/ml_optimizer/tests/test_strategies.py
@@ -1,0 +1,32 @@
+from TradingBotTV.ml_optimizer import (
+    grid_levels,
+    dca_schedule,
+    scalp_signal,
+    choose_strategy,
+)
+
+
+def test_grid_levels_length_and_order():
+    levels = grid_levels(100.0, 1.0, 2)
+    assert len(levels) == 4
+    assert levels[0] < 100.0 < levels[-1]
+
+
+def test_dca_schedule_sum():
+    sched = dca_schedule(100.0, 4)
+    assert len(sched) == 4
+    assert abs(sum(sched) - 100.0) < 1e-9
+
+
+def test_scalp_signal_buy_sell():
+    prices = [1.0, 1.0, 1.0, 1.1]
+    assert scalp_signal(prices, window=2) == 1
+    prices[-1] = 0.9
+    assert scalp_signal(prices, window=2) == -1
+
+
+def test_choose_strategy_branches():
+    assert choose_strategy(0.06, 0.1) == "scalping"
+    assert choose_strategy(0.03, 0.1) == "grid"
+    assert choose_strategy(0.01, 0.6) == "arbitrage"
+    assert choose_strategy(0.01, 0.1) == "dca"

--- a/TradingBotTV/ml_optimizer/tests/test_web_panel.py
+++ b/TradingBotTV/ml_optimizer/tests/test_web_panel.py
@@ -29,3 +29,17 @@ def test_run_dashboard(tmp_path):
     }
     assert expected <= set(ids)
     assert len(app.layout.children) >= 2
+
+
+def test_run_dashboard_with_risk(tmp_path):
+    csv = tmp_path / "metrics.csv"
+    df = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T00:00:00"],
+            "name": ["pnl"],
+            "value": [1],
+        }
+    )
+    df.to_csv(csv, index=False, header=False)
+    app = run_dashboard(csv, risk_charts=True)
+    assert len(app.layout.children) >= 2

--- a/TradingBotTV/ml_optimizer/web_panel.py
+++ b/TradingBotTV/ml_optimizer/web_panel.py
@@ -18,6 +18,7 @@ def run_dashboard(
     path: str | Path = MONITOR_FILE,
     extra_charts: bool = True,
     include_credentials: bool = True,
+    risk_charts: bool = False,
 ) -> Dash:
     """Return a Dash app with metrics from ``path`` and simple controls."""
     df = pd.read_csv(path, names=["timestamp", "name", "value"])
@@ -33,6 +34,11 @@ def run_dashboard(
     if extra_charts and "pnl" in pivot.columns:
         fig2 = px.bar(pivot, x="timestamp", y="pnl", title="PnL")
         charts.append(dcc.Graph(figure=fig2))
+    if risk_charts and "pnl" in pivot.columns:
+        from .visualizer import plot_risk_indicators
+
+        risk_fig = plot_risk_indicators(path)
+        charts.append(dcc.Graph(figure=risk_fig))
 
     controls = []
     if include_credentials:


### PR DESCRIPTION
## Summary
- clarify in AGENTS how to verify pandas, numpy, tensorflow and flake8 are installed
- mention dependency check commands in the README contribution guide
- implement grid, DCA, scalping and arbitrage strategy selector
- document new module in README

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pip show pandas numpy tensorflow flake8`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686455f090208320818541448f1238db