### PR TITLE
Fix trailing whitespace in __init__

### DIFF
--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -161,5 +161,4 @@ __all__ = [
     "scalp_signal",
     "choose_strategy",
     "choose_strategy",
-    
-] 
+]


### PR DESCRIPTION
## Summary
- remove whitespace-only line at end of `TradingBotTV/ml_optimizer/__init__.py`
- ensure no trailing spaces remain

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pip install flake8`
- `flake8 TradingBotTV/ml_optimizer/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686506e307288320a897efe77df21e91