### PR TITLE
Add AutoML tuning and social media sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,14 @@ w środowiskach asynchronicznych.
 * `alerts.py` – powiadomienia Telegram o zleceniach i błędach
 * `deep_rl_examples.py` – przykładowe algorytmy głębokiego RL do adaptacyjnych strategii
 * `advanced_rl.py` – sieci LSTM i prosty DQN z trybem online
+* `detect_price_anomalies` w `analytics.py` – wykrywanie nietypowych ruchów cen
+* `auto_select_best_strategy` w `compare_strategies.py` – automatyczny wybór strategii (walidacja czasowa)
+* `should_switch_strategy` w `compare_strategies.py` – kiedy przełączyć się na nową technikę
+* `online_q_learning` w `deep_rl_examples.py` – uczenie Q-learning na bieżących danych
 * `strategies.py` – grid trading, DCA, scalping i wybór najlepszej techniki
+* `optuna_optimize` w `auto_ml.py` – tuning parametrów z wykorzystaniem Optuna
+* `fetch_social_media_sentiment` w `sentiment.py` – analiza mediów społecznościowych
+* `autoencoder_anomaly_scores` w `analytics.py` – wykrywanie anomalii autoenkoderem
 
 Aby uruchomić test porównawczy strategii:
 ```bash

--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -10,6 +10,10 @@ from .backtest import (
     compute_sma,
     compute_rsi,
 )
+from .compare_strategies import (
+    auto_select_best_strategy,
+    should_switch_strategy,
+)
 from .data_fetcher import (
     fetch_klines,
     async_fetch_klines,
@@ -35,7 +39,10 @@ from .analytics import (
     bollinger_bands,
     stochastic_oscillator,
     order_book_imbalance,
+    detect_price_anomalies,
+    autoencoder_anomaly_scores,
 )
+from .auto_ml import optuna_optimize
 from .ml_models import (
     train_predictive_model,
     optimize_predictive_model,
@@ -75,6 +82,7 @@ from .visualizer import (
     plot_risk_indicators,
 )
 from .deep_rl_examples import deep_q_learning_example, policy_gradient_example
+from .deep_rl_examples import online_q_learning
 from .websocket_orderbook import stream_order_book
 from .database import (
     init_db,
@@ -96,6 +104,9 @@ __all__ = [
     "backtest_strategy",
     "backtest_macd_strategy",
     "compare_strategies",
+    "auto_select_best_strategy",
+    "should_switch_strategy",
+    "optuna_optimize",
     "fetch_klines",
     "async_fetch_klines",
     "get_logger",
@@ -113,6 +124,8 @@ __all__ = [
     "bollinger_bands",
     "stochastic_oscillator",
     "order_book_imbalance",
+    "detect_price_anomalies",
+    "autoencoder_anomaly_scores",
     "train_predictive_model",
     "optimize_predictive_model",
     "backtest_tick_strategy",
@@ -153,6 +166,7 @@ __all__ = [
     "max_drawdown",
     "deep_q_learning_example",
     "policy_gradient_example",
+    "online_q_learning",
     "position_size_from_var",
     "limit_price_from_spread",
     "adjust_order_price",

--- a/TradingBotTV/ml_optimizer/auto_ml.py
+++ b/TradingBotTV/ml_optimizer/auto_ml.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import optuna
+
+from .data_fetcher import fetch_klines
+from .backtest import backtest_strategy
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def optuna_optimize(symbol: str, trials: int = 20) -> tuple[int, int, float]:
+    """Optimize RSI thresholds for ``symbol`` using Optuna."""
+    df = fetch_klines(symbol, interval="1h", limit=500)
+    if df.empty:
+        raise ValueError("no data for optimization")
+
+    def objective(trial: optuna.Trial) -> float:
+        buy_th = trial.suggest_int("buy_th", 10, 50)
+        sell_th = trial.suggest_int("sell_th", 50, 90)
+        pnl = backtest_strategy(
+            df, rsi_buy_threshold=buy_th, rsi_sell_threshold=sell_th
+        )
+        return -pnl
+
+    study = optuna.create_study()
+    study.optimize(objective, n_trials=trials)
+    best_buy = study.best_params["buy_th"]
+    best_sell = study.best_params["sell_th"]
+    best_pnl = -study.best_value
+    logger.info(
+        "Optuna best params: Buy=%s Sell=%s PnL=%.2f",
+        best_buy,
+        best_sell,
+        best_pnl,
+    )
+    return best_buy, best_sell, best_pnl

--- a/TradingBotTV/ml_optimizer/compare_strategies.py
+++ b/TradingBotTV/ml_optimizer/compare_strategies.py
@@ -1,4 +1,7 @@
 from .data_fetcher import fetch_klines
+import numpy as np
+from sklearn.model_selection import TimeSeriesSplit
+
 from .backtest import compare_strategies
 from .logger import get_logger
 
@@ -16,6 +19,39 @@ def run(symbol: str) -> None:
         logger.info('%s PnL: %s', name, pnl)
     best = max(results, key=results.get)
     logger.info('Najlepsza strategia: %s', best)
+
+
+def auto_select_best_strategy(symbol: str, splits: int = 3) -> str:
+    """Return best strategy using time-series cross validation."""
+    df = fetch_klines(symbol, interval="1h", limit=500)
+    if df.empty:
+        raise ValueError("no data for auto selection")
+
+    cv = TimeSeriesSplit(n_splits=splits)
+    scores: dict[str, list[float]] = {}
+    for _, test_idx in cv.split(df):
+        res = compare_strategies(df.iloc[test_idx])
+        for name, pnl in res.items():
+            scores.setdefault(name, []).append(pnl)
+
+    avg_scores = {n: float(np.mean(v)) for n, v in scores.items()}
+    best = max(avg_scores, key=avg_scores.get)
+    logger.info("Auto selected best strategy: %s", best)
+    return best
+
+
+def should_switch_strategy(
+    current: str, scores: dict[str, float], threshold: float = 0.05
+) -> bool:
+    """Return ``True`` if a new strategy beats ``current`` by ``threshold``."""
+    if current not in scores:
+        raise ValueError("current strategy score missing")
+    best = max(scores, key=scores.get)
+    if best == current:
+        return False
+    improvement = scores[best] - scores[current]
+    base = abs(scores[current]) if scores[current] != 0 else 1.0
+    return improvement >= base * threshold
 
 
 if __name__ == '__main__':

--- a/TradingBotTV/ml_optimizer/requirements.txt
+++ b/TradingBotTV/ml_optimizer/requirements.txt
@@ -7,3 +7,4 @@ scipy
 matplotlib
 dash
 tensorflow==2.16.2
+optuna

--- a/TradingBotTV/ml_optimizer/sentiment.py
+++ b/TradingBotTV/ml_optimizer/sentiment.py
@@ -40,3 +40,15 @@ def fetch_lunarcrush_score(symbol: str, api_key: str | None = None) -> float:
     response.raise_for_status()
     data = response.json()
     return float(data["data"][0]["galaxy_score"])
+
+
+def fetch_social_media_sentiment(
+    symbol: str, endpoint: str = "https://api.socialsentiment.io/search"
+) -> float:
+    """Return sentiment score from social posts about ``symbol``."""
+    params = {"q": symbol}
+    response = requests.get(endpoint, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    texts = [post["text"] for post in data.get("posts", [])]
+    return text_sentiment(texts)

--- a/TradingBotTV/ml_optimizer/tests/test_analytics.py
+++ b/TradingBotTV/ml_optimizer/tests/test_analytics.py
@@ -28,3 +28,15 @@ def test_order_book_imbalance_balanced():
     bids = pd.Series([10, 20])
     asks = pd.Series([10, 20])
     assert analytics.order_book_imbalance(bids, asks) == 0
+
+
+def test_detect_price_anomalies_flags():
+    series = pd.Series([1.0]*5 + [10.0] + [1.0]*5)
+    flags = analytics.detect_price_anomalies(series, contamination=0.1)
+    assert flags.any()
+
+
+def test_autoencoder_anomaly_scores_length():
+    series = pd.Series([1.0] * 15)
+    scores = analytics.autoencoder_anomaly_scores(series, window=5, epochs=1)
+    assert len(scores) == len(series) - 5

--- a/TradingBotTV/ml_optimizer/tests/test_auto_ml.py
+++ b/TradingBotTV/ml_optimizer/tests/test_auto_ml.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import auto_ml  # noqa: E402
+
+
+def test_optuna_optimize(monkeypatch):
+    df = pd.DataFrame({"close": [1, 2, 3, 4, 5]})
+    monkeypatch.setattr(auto_ml, "fetch_klines", lambda *a, **k: df)
+    monkeypatch.setattr(auto_ml, "backtest_strategy", lambda *a, **k: 1.0)
+    buy, sell, pnl = auto_ml.optuna_optimize("BTCUSDT", trials=1)
+    assert 10 <= buy <= 50
+    assert 50 <= sell <= 90
+    assert pnl == 1.0

--- a/TradingBotTV/ml_optimizer/tests/test_auto_strategy.py
+++ b/TradingBotTV/ml_optimizer/tests/test_auto_strategy.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from TradingBotTV.ml_optimizer import compare_strategies as cs  # noqa: E402
+
+
+def test_auto_select_best_strategy(monkeypatch):
+    monkeypatch.setattr(
+        cs,
+        "fetch_klines",
+        lambda *a, **k: pd.DataFrame({"close": [1, 2, 3, 4, 5, 4, 3, 2, 1]})
+    )
+    monkeypatch.setattr(
+        cs,
+        "compare_strategies",
+        lambda df: {"s1": df["close"].sum(), "s2": -df["close"].sum()}
+    )
+    best = cs.auto_select_best_strategy("TEST", splits=2)
+    assert best == "s1"
+
+
+def test_should_switch_strategy():
+    scores = {"s1": 10.0, "s2": 12.0}
+    assert cs.should_switch_strategy("s1", scores, threshold=0.1)
+    assert not cs.should_switch_strategy("s2", scores)

--- a/TradingBotTV/ml_optimizer/tests/test_deep_rl_examples.py
+++ b/TradingBotTV/ml_optimizer/tests/test_deep_rl_examples.py
@@ -8,10 +8,17 @@ if str(ROOT_DIR) not in sys.path:
 
 from TradingBotTV.ml_optimizer.deep_rl_examples import (  # noqa: E402
     deep_q_learning_example,
+    online_q_learning,
 )
 
 
 def test_deep_q_learning_example_runs():
     prices = pd.Series([1.0, 1.1, 1.2, 1.1, 1.3])
     rewards = deep_q_learning_example(prices, episodes=3)
+    assert len(rewards) == 3
+
+
+def test_online_q_learning_runs():
+    prices = [1.0, 1.1, 1.2, 1.3]
+    rewards = online_q_learning(prices)
     assert len(rewards) == 3

--- a/TradingBotTV/ml_optimizer/tests/test_sentiment.py
+++ b/TradingBotTV/ml_optimizer/tests/test_sentiment.py
@@ -34,3 +34,12 @@ def test_fetch_lunarcrush_score(monkeypatch):
     monkeypatch.setattr("requests.get", dummy_get)
     score = sentiment.fetch_lunarcrush_score("BTC")
     assert score == 67.0
+
+
+def test_fetch_social_media_sentiment(monkeypatch):
+    def dummy_get(url, params=None, timeout=10):
+        return DummyResponse({"posts": [{"text": "good"}, {"text": "bad"}]})
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    score = sentiment.fetch_social_media_sentiment("BTC")
+    assert score == 0.0

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -26,7 +26,14 @@ Poniżej znajduje się opis plików i katalogów w repozytorium. Wszystkie nazwy
 - `auto_optimizer.py` – losowe poszukiwanie najlepszych progów RSI; wyniki zapisywane są w `model_state.json`.
 - `optimizer.py` – przykład prostej optymalizacji parametrów w pętli.
 - `compare_strategies.py` – porównanie wyników strategii RSI i MACD.
+- `auto_select_best_strategy` w `compare_strategies.py` – automatyczny wybór najlepszej techniki (walidacja czasowa).
+- `should_switch_strategy` w `compare_strategies.py` – podejmuje decyzję o zmianie strategii.
+- `detect_price_anomalies` w `analytics.py` – wskazuje anomalie cenowe.
+- `online_q_learning` w `deep_rl_examples.py` – uczy model na strumieniu danych.
 - `rl_optimizer.py` – rozbudowany przykład uczenia ze wzmocnieniem.
+- `optuna_optimize` w `auto_ml.py` – tuning parametrów z wykorzystaniem Optuna.
+- `fetch_social_media_sentiment` w `sentiment.py` – analiza mediów społecznościowych.
+- `autoencoder_anomaly_scores` w `analytics.py` – wykrywanie anomalii autoenkoderem.
 - `github_strategy_simulator.py` – pobieranie strategii z publicznych repozytoriów
   i ich symulacja offline.
 - `portfolio.py` – alokacja kapitału na wiele par jednocześnie


### PR DESCRIPTION
## Summary
- implement `optuna_optimize` for automated parameter search
- expose autoencoder-based anomaly scores and social sentiment fetcher
- extend Polish and English docs with new analytics utilities
- test new optimization and analytics helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650c18799c83209bf6de991199ad9a