### PR TITLE
Update bot for margin test trading

### DIFF
--- a/TradingBotTV/bot/BinanceTrader.cs
+++ b/TradingBotTV/bot/BinanceTrader.cs
@@ -137,7 +137,7 @@ namespace Bot
 
         private string GetOrderUrl(string symbol, string side, decimal quantity)
         {
-            var endpoint = "https://api.binance.com/api/v3/order/test"; // test order for safety
+            var endpoint = "https://api.binance.com/sapi/v1/margin/order/test"; // margin test order
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             var query = $"symbol={symbol}&side={side}&type=MARKET&quantity={quantity}&timestamp={timestamp}";
             var signature = Sign(query);

--- a/TradingBotTV/ml_optimizer/hft.py
+++ b/TradingBotTV/ml_optimizer/hft.py
@@ -57,7 +57,7 @@ async def fast_market_order(
 ) -> Dict:
     """Send a quick market order via ``session`` and return JSON response."""
 
-    url = "https://api.binance.com/api/v3/order/test"
+    url = "https://api.binance.com/sapi/v1/margin/order/test"
     params = {
         "symbol": symbol,
         "side": side,


### PR DESCRIPTION
## Summary
- use Binance margin test endpoint in C# and Python trading helpers

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pip show pandas numpy tensorflow flake8`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686516712df48320b27581d2d492b07a