### PR TITLE
Replace Telegram alerts with Discord notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Wprowadzono również moduł `paper_trading`, który pozwala na testowanie strat
 4. W tym samym pliku możesz zmienić takie parametry jak `stopLossPercent`,
    `takeProfitPercent`, `trailingStopPercent`, `maxDrawdownPercent` oraz okresy
    EMA.
+5. Aby otrzymywać powiadomienia na Discordzie, ustaw zmienną
+   `DISCORD_WEBHOOK_URL` lub wpisz `webhookUrl` w sekcji `discord` pliku
+   `settings.json`. Szczegóły w [docs/discord.md](docs/discord.md).
 
 ## Uruchomienie
 1. W katalogu `TradingBotTV/bot` uruchom aplikację:
@@ -166,7 +169,7 @@ w środowiskach asynchronicznych.
   dodatkowymi wskaźnikami ryzyka oraz formularzem do wpisania kluczy API
   i przyciskiem start/stop
 * `signal_handler.py` – rozszerzona obsługa sygnałów TradingView
-* `alerts.py` – powiadomienia Telegram o zleceniach i błędach
+* `alerts.py` – powiadomienia Discord o zleceniach i błędach
 * `deep_rl_examples.py` – przykładowe algorytmy głębokiego RL do adaptacyjnych strategii
 * `advanced_rl.py` – sieci LSTM i prosty DQN z trybem online
 * `detect_price_anomalies` w `analytics.py` – wykrywanie nietypowych ruchów cen

--- a/TradingBotTV/bot/ConfigManager.cs
+++ b/TradingBotTV/bot/ConfigManager.cs
@@ -91,13 +91,9 @@ namespace Bot
         public static string TradingViewWsUrl =>
             _config["websocket"]?["tradingViewUrl"]?.ToString() ?? string.Empty;
 
-        public static string TelegramToken =>
-            Environment.GetEnvironmentVariable("TELEGRAM_TOKEN")
-            ?? _config["telegram"]?["token"]?.ToString() ?? string.Empty;
-
-        public static string TelegramChatId =>
-            Environment.GetEnvironmentVariable("TELEGRAM_CHAT_ID")
-            ?? _config["telegram"]?["chatId"]?.ToString() ?? string.Empty;
+        public static string DiscordWebhookUrl =>
+            Environment.GetEnvironmentVariable("DISCORD_WEBHOOK_URL")
+            ?? _config["discord"]?["webhookUrl"]?.ToString() ?? string.Empty;
 
         public static void Reload() => Load();
 

--- a/TradingBotTV/bot/TradeLogger.cs
+++ b/TradingBotTV/bot/TradeLogger.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Bot
@@ -17,25 +16,19 @@ namespace Bot
         private static readonly object _lock = new object();
         private static readonly HttpClient _http = new HttpClient();
 
-        private static async Task SendTelegramAlertAsync(string message)
+        private static async Task SendDiscordAlertAsync(string message)
         {
-            var token = ConfigManager.TelegramToken;
-            var chat = ConfigManager.TelegramChatId;
-            if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(chat))
+            var hook = ConfigManager.DiscordWebhookUrl;
+            if (string.IsNullOrWhiteSpace(hook))
                 return;
             try
             {
-                var url = $"https://api.telegram.org/bot{token}/sendMessage";
-                var data = new FormUrlEncodedContent(new[]
-                {
-                    new KeyValuePair<string, string>("chat_id", chat),
-                    new KeyValuePair<string, string>("text", message),
-                });
-                await _http.PostAsync(url, data).ConfigureAwait(false);
+                var data = new StringContent($"{{\"content\":\"{message}\"}}");
+                await _http.PostAsync(hook, data).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"⚠️ Telegram alert failed: {ex.Message}");
+                Console.WriteLine($"⚠️ Discord alert failed: {ex.Message}");
             }
         }
 
@@ -65,7 +58,7 @@ namespace Bot
                     price
                 );
 
-                _ = SendTelegramAlertAsync($"Trade {side} {amount} {symbol} at {price:F2}");
+                _ = SendDiscordAlertAsync($"Trade {side} {amount} {symbol} at {price:F2}");
 
             }
             catch (Exception ex)

--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -93,7 +93,7 @@ from .database import (
 )
 from .web_panel import run_dashboard
 from .signal_handler import parse_tradingview_payload, execute_strategies
-from .alerts import send_telegram_message
+from .alerts import send_discord_message
 
 __all__ = [
     "compute_rsi",
@@ -159,7 +159,7 @@ __all__ = [
     "run_dashboard",
     "parse_tradingview_payload",
     "execute_strategies",
-    "send_telegram_message",
+    "send_discord_message",
     "adaptive_stop_levels",
     "cache_fundamental_data",
     "cache_fundamental_data_regularly",

--- a/TradingBotTV/ml_optimizer/alerts.py
+++ b/TradingBotTV/ml_optimizer/alerts.py
@@ -1,4 +1,4 @@
-"""Telegram alert utilities."""
+"""Discord alert utilities."""
 
 from __future__ import annotations
 
@@ -6,17 +6,14 @@ import os
 import requests
 
 
-def send_telegram_message(
+def send_discord_message(
     message: str,
     *,
-    token: str | None = None,
-    chat_id: str | None = None,
+    webhook_url: str | None = None,
 ) -> None:
-    """Send *message* using Telegram bot API."""
-    token = token or os.getenv("TELEGRAM_TOKEN")
-    chat_id = chat_id or os.getenv("TELEGRAM_CHAT_ID")
-    if not token or not chat_id:
-        raise ValueError("token and chat_id must be provided")
-    url = f"https://api.telegram.org/bot{token}/sendMessage"
-    data = {"chat_id": chat_id, "text": message}
-    requests.post(url, data=data, timeout=10)
+    """Send ``message`` to a Discord channel using a webhook."""
+    webhook_url = webhook_url or os.getenv("DISCORD_WEBHOOK_URL")
+    if not webhook_url:
+        raise ValueError("webhook_url must be provided")
+    data = {"content": message}
+    requests.post(webhook_url, json=data, timeout=10)

--- a/TradingBotTV/ml_optimizer/auto_optimizer.py
+++ b/TradingBotTV/ml_optimizer/auto_optimizer.py
@@ -7,7 +7,7 @@ from .data_fetcher import fetch_klines
 from .backtest import backtest_strategy
 from .logger import get_logger
 from .monitor import record_metric
-from .alerts import send_telegram_message
+from .alerts import send_discord_message
 from .state_utils import (
     load_state as load_json_state,
     save_state as save_json_state,
@@ -81,7 +81,7 @@ def optimize(symbol: str, iterations: int = 20) -> tuple[int, int, float]:
             f"Optimizer updated: Buy={best_buy} "
             f"Sell={best_sell} PnL={best_pnl:.2f}"
         )
-        send_telegram_message(msg)
+        send_discord_message(msg)
     except Exception:
         pass
     return best_buy, best_sell, best_pnl

--- a/TradingBotTV/ml_optimizer/rl_optimizer.py
+++ b/TradingBotTV/ml_optimizer/rl_optimizer.py
@@ -10,7 +10,7 @@ from .data_fetcher import fetch_klines
 from .backtest import backtest_strategy
 from .logger import get_logger
 from .monitor import record_metric
-from .alerts import send_telegram_message
+from .alerts import send_discord_message
 from .state_utils import (
     load_state as load_json_state,
     save_state as save_json_state,
@@ -130,7 +130,7 @@ def train(
     record_metric('rl_optimizer_buy', best_buy)
     record_metric('rl_optimizer_sell', best_sell)
     try:
-        send_telegram_message(
+        send_discord_message(
             f"RL optimizer params: Buy={best_buy} Sell={best_sell}"
         )
     except Exception:

--- a/TradingBotTV/ml_optimizer/tests/test_alerts.py
+++ b/TradingBotTV/ml_optimizer/tests/test_alerts.py
@@ -8,14 +8,14 @@ if str(ROOT_DIR) not in sys.path:
 from TradingBotTV.ml_optimizer import alerts  # noqa: E402
 
 
-def test_send_telegram_message(monkeypatch):
+def test_send_discord_message(monkeypatch):
     called = {}
 
-    def fake_post(url, data, timeout):
+    def fake_post(url, json, timeout):
         called['url'] = url
-        called['data'] = data
+        called['data'] = json
         return type('Resp', (), {'status_code': 200})()
 
     monkeypatch.setattr("requests.post", fake_post)
-    alerts.send_telegram_message("hi", token="t", chat_id="c")
-    assert called['data']['text'] == "hi"
+    alerts.send_discord_message("hi", webhook_url="hook")
+    assert called['data']['content'] == "hi"

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,0 +1,14 @@
+# Jak włączyć powiadomienia Discord
+
+1. Na swoim serwerze Discord wejdź w ustawienia kanału i wybierz **Integracje**.
+2. Utwórz nowy webhook i skopiuj jego adres URL.
+3. Ustaw zmienną środowiskową `DISCORD_WEBHOOK_URL` z uzyskanym adresem
+   lub wpisz go w pliku `TradingBotTV/config/settings.json` w sekcji `discord`:
+   
+   ```json
+   {
+       "discord": {"webhookUrl": "https://discord.com/api/webhooks/..."}
+   }
+   ```
+4. Po uruchomieniu bota każda transakcja i ważna zmiana zostanie wysłana
+   na wskazany kanał.


### PR DESCRIPTION
## Summary
- remove Telegram messaging utilities
- add Discord webhook alerts and instructions
- update C# bot to use Discord webhooks
- provide docs for configuring Discord notifications
- adjust unit tests and README

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_686525359d2483209bac09c4596fa907