### PR TITLE
Add TradingView iframe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ w środowiskach asynchronicznych.
 * `visualizer.py` – wizualizacja statystyk z `monitor.py` oraz ryzyka portfela
 * `database.py` – zapisywanie transakcji i metryk w bazie SQLite/PostgreSQL
 * `web_panel.py` – panel Dash z wykresami wyników,
-  dodatkowymi wskaźnikami ryzyka oraz formularzem do wpisania kluczy API
-  i przyciskiem start/stop
+  dodatkowymi wskaźnikami ryzyka oraz formularzem do wpisania kluczy API,
+  przyciskiem start/stop i opcjonalnym wykresem TradingView
 * `signal_handler.py` – rozszerzona obsługa sygnałów TradingView
 * `alerts.py` – powiadomienia Discord o zleceniach i błędach
 * `deep_rl_examples.py` – przykładowe algorytmy głębokiego RL do adaptacyjnych strategii

--- a/TradingBotTV/ml_optimizer/tests/test_web_panel.py
+++ b/TradingBotTV/ml_optimizer/tests/test_web_panel.py
@@ -7,6 +7,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from TradingBotTV.ml_optimizer.web_panel import run_dashboard  # noqa: E402
+from dash import html  # noqa: E402
 
 
 def test_run_dashboard(tmp_path):
@@ -43,3 +44,19 @@ def test_run_dashboard_with_risk(tmp_path):
     df.to_csv(csv, index=False, header=False)
     app = run_dashboard(csv, risk_charts=True)
     assert len(app.layout.children) >= 2
+
+
+def test_run_dashboard_with_tradingview(tmp_path):
+    csv = tmp_path / "metrics.csv"
+    df = pd.DataFrame(
+        {"timestamp": ["2024-01-01T00:00:00"], "name": ["m"], "value": [1]}
+    )
+    df.to_csv(csv, index=False, header=False)
+    url = "https://example.com/chart"
+    app = run_dashboard(csv, tradingview_url=url)
+    found = False
+    for comp in app.layout.children[1:]:
+        if isinstance(comp, html.Iframe) and comp.src == url:
+            found = True
+            break
+    assert found

--- a/TradingBotTV/ml_optimizer/web_panel.py
+++ b/TradingBotTV/ml_optimizer/web_panel.py
@@ -19,8 +19,13 @@ def run_dashboard(
     extra_charts: bool = True,
     include_credentials: bool = True,
     risk_charts: bool = False,
+    tradingview_url: str | None = None,
 ) -> Dash:
-    """Return a Dash app with metrics from ``path`` and simple controls."""
+    """Return a Dash app with metrics from ``path`` and simple controls.
+
+    If ``tradingview_url`` is provided, an iframe with the given address is
+    appended below the charts.
+    """
     df = pd.read_csv(path, names=["timestamp", "name", "value"])
     if df.empty:
         raise ValueError("metrics file is empty")
@@ -39,6 +44,13 @@ def run_dashboard(
 
         risk_fig = plot_risk_indicators(path)
         charts.append(dcc.Graph(figure=risk_fig))
+    if tradingview_url:
+        charts.append(
+            html.Iframe(
+                src=tradingview_url,
+                style={"border": "0", "width": "100%", "height": "600px"},
+            )
+        )
 
     controls = []
     if include_credentials:

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -126,6 +126,8 @@ Jeśli ustawisz zmienne `DASHBOARD_USERNAME` i `DASHBOARD_PASSWORD`, panel
 poprosi o podanie danych logowania. Znajdziesz tam kafelki z podsumowaniem PnL,
 wielkości pozycji oraz przycisk do włączania i wyłączania handlu. Możesz
 również podejrzeć ostatni log transakcji.
+Jeżeli do funkcji `run_dashboard` przekażesz parametr `tradingview_url`,
+panel wyświetli dodatkowo wykres TradingView w ramce iframe.
 
 ## Jak uruchomić testy
 


### PR DESCRIPTION
## Summary
- extend `run_dashboard` with `tradingview_url` param
- embed TradingView iframe in `web_panel.py`
- update docs and README with new feature
- test dashboard tradingview option

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686536cd4d748320abd16ed45876c025