### PR TITLE
Fix lint error in ml_optimizer __init__

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,5 @@ BOT_ENV_FILE=.env
 DASHBOARD_USERNAME=admin
 DASHBOARD_PASSWORD=secret
 WEBHOOK_TOKEN=change_me
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your_webhook
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ Wprowadzono również moduł `paper_trading`, który pozwala na testowanie strat
 4. W tym samym pliku możesz zmienić takie parametry jak `stopLossPercent`,
    `takeProfitPercent`, `trailingStopPercent`, `maxDrawdownPercent` oraz okresy
    EMA.
-5. Aby otrzymywać powiadomienia na Discordzie, ustaw zmienną
-   `DISCORD_WEBHOOK_URL` lub wpisz `webhookUrl` w sekcji `discord` pliku
-   `settings.json`. Szczegóły w [docs/discord.md](docs/discord.md).
+5. Aby połączyć bota z Discordem, utwórz webhook na swoim serwerze i
+   wpisz jego adres w zmiennej `DISCORD_WEBHOOK_URL` albo w polu
+   `webhookUrl` sekcji `discord` w pliku `settings.json`.
+   Dokładny opis znajduje się w
+   [docs/discord.md](docs/discord.md).
 
 ## Uruchomienie
 1. W katalogu `TradingBotTV/bot` uruchom aplikację:

--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -180,5 +180,5 @@ __all__ = [
     "choose_strategy",
     "choose_strategy",
     "fetch_political_crypto_hashtags",
-    "generate_expert_report", 
+    "generate_expert_report",
 ]

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -2,13 +2,18 @@
 
 1. Na swoim serwerze Discord wejdź w ustawienia kanału i wybierz **Integracje**.
 2. Utwórz nowy webhook i skopiuj jego adres URL.
-3. Ustaw zmienną środowiskową `DISCORD_WEBHOOK_URL` z uzyskanym adresem
-   lub wpisz go w pliku `TradingBotTV/config/settings.json` w sekcji `discord`:
+3. Wpisz adres w zmiennej `DISCORD_WEBHOOK_URL` lub w polu
+   `webhookUrl` w `TradingBotTV/config/settings.json`:
    
    ```json
    {
        "discord": {"webhookUrl": "https://discord.com/api/webhooks/..."}
    }
    ```
-4. Po uruchomieniu bota każda transakcja i ważna zmiana zostanie wysłana
-   na wskazany kanał.
+4. Zapisz plik `.env` i uruchom bota lub przetestuj połączenie poleceniem:
+
+   ```bash
+   python -c "from TradingBotTV.ml_optimizer.alerts import send_discord_message; send_discord_message('test')"
+   ```
+
+   Jeśli widzisz wiadomość testową, integracja działa.


### PR DESCRIPTION
## Summary
- remove trailing whitespace in `TradingBotTV/ml_optimizer/__init__.py`
- document how to configure Discord alerts
- add `DISCORD_WEBHOOK_URL` to example `.env`

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pip show pandas numpy tensorflow flake8`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68657bd7e91483208ab65c5141070313