### PR TITLE
Fix flake8 line length errors in GUI panel

### DIFF
--- a/TradingBotTV/gui_panel.py
+++ b/TradingBotTV/gui_panel.py
@@ -33,10 +33,18 @@ def create_app(
     except Exception:
         cfg = {"binance": {}, "trading": {}}
 
-    api_key_var = tk.StringVar(value=cfg.get("binance", {}).get("apiKey", ""))
-    api_secret_var = tk.StringVar(value=cfg.get("binance", {}).get("apiSecret", ""))
-    symbol_var = tk.StringVar(value=cfg.get("trading", {}).get("symbol", ""))
-    amount_var = tk.StringVar(value=str(cfg.get("trading", {}).get("amount", "")))
+    api_key_var = tk.StringVar(
+        value=cfg.get("binance", {}).get("apiKey", "")
+    )
+    api_secret_var = tk.StringVar(
+        value=cfg.get("binance", {}).get("apiSecret", "")
+    )
+    symbol_var = tk.StringVar(
+        value=cfg.get("trading", {}).get("symbol", "")
+    )
+    amount_var = tk.StringVar(
+        value=str(cfg.get("trading", {}).get("amount", ""))
+    )
     trading_var = tk.BooleanVar(value=True)
     training_var = tk.BooleanVar(value=False)
 
@@ -64,13 +72,17 @@ def create_app(
     cfg_frame.pack(padx=5, pady=5, fill=tk.X)
 
     tk.Label(cfg_frame, text="API Key").grid(row=0, column=0, sticky="e")
-    tk.Entry(cfg_frame, textvariable=api_key_var, width=40).grid(row=0, column=1, padx=5)
+    tk.Entry(cfg_frame, textvariable=api_key_var, width=40) \
+        .grid(row=0, column=1, padx=5)
     tk.Label(cfg_frame, text="API Secret").grid(row=1, column=0, sticky="e")
-    tk.Entry(cfg_frame, textvariable=api_secret_var, width=40, show="*").grid(row=1, column=1, padx=5)
+    tk.Entry(cfg_frame, textvariable=api_secret_var, width=40, show="*") \
+        .grid(row=1, column=1, padx=5)
     tk.Label(cfg_frame, text="Symbol").grid(row=2, column=0, sticky="e")
-    tk.Entry(cfg_frame, textvariable=symbol_var, width=20).grid(row=2, column=1, sticky="w", padx=5)
+    tk.Entry(cfg_frame, textvariable=symbol_var, width=20) \
+        .grid(row=2, column=1, sticky="w", padx=5)
     tk.Label(cfg_frame, text="Amount").grid(row=3, column=0, sticky="e")
-    tk.Entry(cfg_frame, textvariable=amount_var, width=10).grid(row=3, column=1, sticky="w", padx=5)
+    tk.Entry(cfg_frame, textvariable=amount_var, width=10) \
+        .grid(row=3, column=1, sticky="w", padx=5)
 
     def save_config() -> None:
         data = {"binance": {}, "trading": {}}
@@ -88,7 +100,8 @@ def create_app(
             pass
         CONFIG_FILE.write_text(json.dumps(data, indent=2))
 
-    tk.Button(cfg_frame, text="Save", command=save_config).grid(row=4, column=0, columnspan=2, pady=5)
+    tk.Button(cfg_frame, text="Save", command=save_config) \
+        .grid(row=4, column=0, columnspan=2, pady=5)
     log_text = ScrolledText(root, height=10, width=80)
     log_text.pack(padx=5, pady=5, fill=tk.BOTH, expand=False)
 


### PR DESCRIPTION
## Summary
- wrap variable initialization lines for readability
- wrap Entry and Button calls to stay within 79 characters

## Testing
- `pip install -r TradingBotTV/ml_optimizer/requirements.txt`
- `pip show pandas numpy tensorflow flake8`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865b7cc7b208320ac8ca772023e3c0d