### PR TITLE
Fix PyInstaller build and rename bot

### DIFF
--- a/TradingBotTV/bot/DashboardServer.cs
+++ b/TradingBotTV/bot/DashboardServer.cs
@@ -91,7 +91,8 @@ pre{{white-space:pre-wrap;}}
                 return Task.CompletedTask;
             });
 
-            app.RunAsync("http://localhost:5001", token).GetAwaiter().GetResult();
+            app.Urls.Add("http://localhost:5001");
+            app.RunAsync(token).GetAwaiter().GetResult();
         }
     }
 }

--- a/TradingBotTV/bot/WebhookServer.cs
+++ b/TradingBotTV/bot/WebhookServer.cs
@@ -58,7 +58,8 @@ namespace Bot
                 }
             });
 
-            app.RunAsync("http://localhost:5000", token).GetAwaiter().GetResult();
+            app.Urls.Add("http://localhost:5000");
+            app.RunAsync(token).GetAwaiter().GetResult();
         }
     }
 }

--- a/TradingBotTV/gui_panel.py
+++ b/TradingBotTV/gui_panel.py
@@ -26,7 +26,7 @@ def create_app(
 ) -> tk.Tk:
     """Return a :class:`tkinter.Tk` control panel."""
     root = tk.Tk()
-    root.title("BinanceTraderBot")
+    root.title("Trytonator2137")
 
     try:
         cfg = json.loads(CONFIG_FILE.read_text())

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -4,11 +4,14 @@ import subprocess
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BOT_CSPROJ = PROJECT_ROOT / 'TradingBotTV' / 'bot' / 'BinanceTraderBot.csproj'
-PY_ENTRY = PROJECT_ROOT / 'TradingBotTV' / 'ml_optimizer' / '__main__.py'
+BOT_NAME = 'Trytonator2137'
+# entry point for optimizer CLI
+PY_ENTRY = PROJECT_ROOT / 'TradingBotTV' / 'ml_optimizer' / 'auto_optimizer.py'
 GUI_ENTRY = PROJECT_ROOT / 'TradingBotTV' / 'gui_panel.py'
 
 
 def run(cmd):
+    cmd = [str(c) for c in cmd]
     print('Running:', ' '.join(cmd))
     subprocess.run(cmd, check=True)
 
@@ -24,19 +27,25 @@ def main():
         '-r', 'win-x64',
         '-p:PublishSingleFile=true',
         '--self-contained', 'false',
-        '-o', str(dist_dir / 'binancebot')
+        '-o', str(dist_dir / BOT_NAME)
     ])
+
+    exe_path = dist_dir / BOT_NAME / 'BinanceTraderBot.exe'
+    if exe_path.exists():
+        exe_path.rename(dist_dir / BOT_NAME / f'{BOT_NAME}.exe')
 
     # Build Python optimizer executable
     run([
-        'pyinstaller', '--onefile',
+        'python', '-m', 'PyInstaller', '--onefile',
+        '--name', BOT_NAME,
         '--distpath', str(dist_dir / 'python'),
         str(PY_ENTRY)
     ])
 
     # Build GUI executable
     run([
-        'pyinstaller', '--onefile',
+        'python', '-m', 'PyInstaller', '--onefile',
+        '--name', f'{BOT_NAME}_gui',
         '--distpath', str(dist_dir / 'python'),
         str(GUI_ENTRY)
     ])


### PR DESCRIPTION
## Summary
- update installer script to use python module execution
- configure output names for Trytonator2137
- rename GUI window title
- install dotnet/pyinstaller and run tests

## Testing
- `flake8`
- `pytest`
- `python scripts/build_installer.py`

------
https://chatgpt.com/codex/tasks/task_e_6866ef7a15d08320bf9d2b3ae06dfdbc