### PR TITLE
Revert Optional use and require Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Wprowadzono również moduł `paper_trading`, który pozwala na testowanie strat
 
 ## Wymagania
 - .NET 8 SDK
-- Python 3.8+
+- Python 3.10+
 
 ## Instalacja
 1. Zainstaluj pakiet `.NET 8 SDK`:

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -56,7 +56,7 @@ Poniżej znajduje się opis plików i katalogów w repozytorium. Wszystkie nazwy
 
 ## Instalacja i konfiguracja
 
-1. Zainstaluj Python 3.8+ oraz .NET 8 SDK.
+1. Zainstaluj Python 3.10+ oraz .NET 8 SDK.
 2. Zainstaluj zależności:
    ```bash
    pip install -r TradingBotTV/ml_optimizer/requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "tradingbottv"
 version = "0.1.0"
 description = "Optimization utilities for BinanceTraderBot"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     {name = "TradingBotTV"}
 ]


### PR DESCRIPTION
## Summary
- restore original union typing in `backtest.py`
- bump required Python version to 3.10
- update docs to state Python 3.10+

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68682fc7f5ac83208d1cf0f2eba067aa