### PR TITLE
Add resource management and multiprocessing

### DIFF
--- a/TradingBotTV/ml_optimizer/__init__.py
+++ b/TradingBotTV/ml_optimizer/__init__.py
@@ -1,5 +1,7 @@
 """Utility exports for the :mod:`TradingBotTV.ml_optimizer` package."""
 
+from .resource_manager import configure_resources as _configure_resources
+
 from .backtest import (
     backtest_macd_strategy,
     backtest_strategy,
@@ -182,3 +184,5 @@ __all__ = [
     "fetch_political_crypto_hashtags",
     "generate_expert_report",
 ]
+
+_configure_resources()

--- a/TradingBotTV/ml_optimizer/requirements.txt
+++ b/TradingBotTV/ml_optimizer/requirements.txt
@@ -8,3 +8,4 @@ matplotlib
 dash
 tensorflow==2.16.2
 optuna
+psutil

--- a/TradingBotTV/ml_optimizer/resource_manager.py
+++ b/TradingBotTV/ml_optimizer/resource_manager.py
@@ -1,0 +1,45 @@
+import resource
+import psutil
+
+try:
+    import tensorflow as tf
+except Exception:  # noqa: BLE001
+    tf = None
+
+
+def configure_resources(
+    ram_fraction: float = 0.75,
+    gpu_fraction: float = 0.75,
+) -> None:
+    """Configure process to use all CPUs and limit RAM/GPU usage."""
+    try:
+        p = psutil.Process()
+        p.cpu_affinity(list(range(psutil.cpu_count())))
+    except Exception:
+        pass
+
+    try:
+        total_mem = psutil.virtual_memory().total
+        limit = int(total_mem * ram_fraction)
+        resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
+    except Exception:
+        pass
+
+    if tf is not None:
+        try:
+            gpus = tf.config.list_physical_devices("GPU")
+            if gpus:
+                # Attempt to cap GPU memory
+                details = tf.config.experimental.get_device_details(gpus[0])
+                total_gpu_mem = details.get("memory_limit")
+                if total_gpu_mem:
+                    tf.config.experimental.set_virtual_device_configuration(
+                        gpus[0],
+                        [
+                            tf.config.experimental.VirtualDeviceConfiguration(
+                                memory_limit=int(total_gpu_mem * gpu_fraction)
+                            )
+                        ],
+                    )
+        except Exception:
+            pass

--- a/TradingBotTV/ml_optimizer/tests/test_rl_optimizer.py
+++ b/TradingBotTV/ml_optimizer/tests/test_rl_optimizer.py
@@ -30,6 +30,6 @@ def test_train_learns_best_thresholds(monkeypatch):
     # Disable state saving
     monkeypatch.setattr(rl, "save_state", lambda state: None)
 
-    buy, sell = rl.train("TEST", episodes=60)
+    buy, sell = rl.train("TEST", episodes=60, use_multiprocessing=False)
     assert abs(buy - 28) <= 6
     assert abs(sell - 72) <= 6


### PR DESCRIPTION
## Summary
- manage CPU, RAM, and GPU usage via new `resource_manager` module
- enable multiprocessing in `rl_optimizer.train` with optional toggle
- invoke resource configuration when `ml_optimizer` is imported
- adjust RL optimizer tests for new parameter
- update dependencies

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68698f7a80fc832093ca32bb453cb1ac